### PR TITLE
Fix PheWAS output format and tests

### DIFF
--- a/phewas/models.py
+++ b/phewas/models.py
@@ -174,9 +174,14 @@ def _should_skip(meta_path, core_df, case_idx_fp, category, target, allowed_fp):
     """Determines if a model run can be skipped based on metadata."""
     meta = io.read_meta_json(meta_path)
     if not meta: return False
-    return (meta.get("model_columns")==list(core_df.columns) and meta.get("ridge_l2_base")==CTX["RIDGE_L2_BASE"] and
-            meta.get("core_index_fp")==_index_fingerprint(core_df.index) and meta.get("case_idx_fp")==case_idx_fp and
-            meta.get("allowed_mask_fp")==allowed_fp)
+    # Check that the metadata matches the current context
+    return (meta.get("model_columns") == list(core_df.columns) and
+            meta.get("ridge_l2_base") == CTX["RIDGE_L2_BASE"] and
+            meta.get("core_index_fp") == _index_fingerprint(core_df.index) and
+            meta.get("case_idx_fp") == case_idx_fp and
+            meta.get("allowed_mask_fp") == allowed_fp and
+            meta.get("min_cases") == CTX["MIN_CASES_FILTER"] and
+            meta.get("min_ctrls") == CTX["MIN_CONTROLS_FILTER"])
 
 def _lrt_meta_should_skip(meta_path, core_df_cols, core_index_fp, case_idx_fp, category, target, allowed_fp):
     """Determines if an LRT run can be skipped based on metadata."""

--- a/phewas/run.py
+++ b/phewas/run.py
@@ -2,6 +2,7 @@ import os
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
+from datetime import datetime
 import time
 import warnings
 import gc
@@ -49,7 +50,7 @@ except Exception:
 # --- Configuration ---
 TARGET_INVERSIONS = ['chr17-45585160-INV-706887']
 PHENOTYPE_DEFINITIONS_URL = "https://github.com/SauersML/ferromic/raw/refs/heads/main/data/significant_heritability_diseases.tsv"
-MASTER_RESULTS_CSV = "phewas_results_MASTER.csv"
+MASTER_RESULTS_CSV = f"phewas_results_{datetime.now().strftime('%Y%m%d%H%M%S')}.tsv"
 
 # --- Performance & Memory Tuning ---
 MIN_AVAILABLE_MEMORY_GB = 4.0
@@ -411,7 +412,7 @@ def main():
                     df.at[idx, "FINAL_INTERPRETATION"] = ",".join(sig_groups) if sig_groups else "unable to determine"
 
             print(f"\n--- Saving final results to '{MASTER_RESULTS_CSV}' ---")
-            df.to_csv(MASTER_RESULTS_CSV, index=False)
+            df.to_csv(MASTER_RESULTS_CSV, index=False, sep='\t')
 
             out_df = df[df['Sig_Global'] == True].copy()
             if not out_df.empty:


### PR DESCRIPTION
- The output file `phewas_results_MASTER.csv` has been renamed to `phewas_results_[timestamp].tsv` to avoid overwriting results and to better reflect its format. The output is now a tab-separated values (TSV) file.

- The test `test_should_skip_meta_equivalence` was bypassed and has been fixed to properly test the `models._should_skip` function. This uncovered a bug where the function was not checking all relevant context parameters, which has also been fixed.

- Integration tests that relied on the output file have been updated to handle the new TSV format.