### PR TITLE
Refactor and apply minor fixes to PheWAS scripts

### DIFF
--- a/phewas/pipes.py
+++ b/phewas/pipes.py
@@ -41,12 +41,14 @@ class MemoryMonitor(threading.Thread):
         self.stop_event = threading.Event()
         self.available_memory_gb = 0
         self.rss_gb = 0
+        self.sys_cpu_percent = 0.0
 
     def run(self):
         while not self.stop_event.is_set():
             if PSUTIL_AVAILABLE:
                 self.available_memory_gb = psutil.virtual_memory().available / (1024**3)
                 self.rss_gb = psutil.Process().memory_info().rss / (1024**3)
+                self.sys_cpu_percent = psutil.cpu_percent(interval=None)
             time.sleep(self.interval)
 
     def stop(self):


### PR DESCRIPTION
This commit applies several small refactorings and fixes to the PheWAS pipeline scripts (`run.py`, `pipes.py`, `models.py`).

Changes include:
- Adding missing `json` import and wrapping `faulthandler.enable()` in a try-except block in `run.py`.
- Parametrizing the PCS cache filename in `run.py` to use the `NUM_PCS` variable.
- Making the baseline RSS memory snapshot in `run.py` safer.
- Removing a duplicated log message in `run.py`.
- Adding CPU usage monitoring to the `MemoryMonitor` in `pipes.py`.
- Refactoring the `_apply_sex_restriction` function in `models.py` to remove dead code and improve clarity.