### PR TITLE
Harden PheWAS follow-up orchestration and statsmodels usage

### DIFF
--- a/phewas/pipes.py
+++ b/phewas/pipes.py
@@ -344,19 +344,20 @@ def run_lrt_followup(core_df_with_const, allowed_mask_by_cat, anc_series, hit_na
                         _print_bar(queued, done, "Ancestry")
 
                 failed_tasks = []
+
                 def _err_cb(e):
                     nonlocal failed_tasks
                     print(f"[pool ERR] Worker failed: {e}", flush=True)
                     failed_tasks.append(e)
 
-                    for task in tasks_follow:
-                        floor = _resolve_floor(min_available_memory_gb)
-                        if PSUTIL_AVAILABLE and 0 < monitor.available_memory_gb < floor:
-                            print(f"\n[gov WARN] Low memory detected (avail: {monitor.available_memory_gb:.2f}GB, floor: {floor:.2f}GB), pausing task submission...", flush=True)
-                            while PSUTIL_AVAILABLE and 0 < monitor.available_memory_gb < floor:
-                                time.sleep(2)
+                for task in tasks_follow:
+                    floor = _resolve_floor(min_available_memory_gb)
+                    if PSUTIL_AVAILABLE and 0 < monitor.available_memory_gb < floor:
+                        print(f"\n[gov WARN] Low memory detected (avail: {monitor.available_memory_gb:.2f}GB, floor: {floor:.2f}GB), pausing task submission...", flush=True)
+                        while PSUTIL_AVAILABLE and 0 < monitor.available_memory_gb < floor:
+                            time.sleep(2)
 
-                        queued += 1
+                    queued += 1
                     pool.apply_async(models.lrt_followup_worker, (task,), callback=_cb2, error_callback=_err_cb)
                     _print_bar(queued, done, "Ancestry")
 

--- a/phewas/tests.py
+++ b/phewas/tests.py
@@ -355,8 +355,8 @@ def test_ridge_intercept_is_zero(test_ctx):
             assert mock_logit.return_value.fit_regularized.called
             args, kwargs = mock_logit.return_value.fit_regularized.call_args
             assert 'alpha' in kwargs
-            assert kwargs['alpha'][X.columns.get_loc('const')] == 0.0
-            assert kwargs['alpha'][X.columns.get_loc('x1')] > 0.0
+            assert isinstance(kwargs['alpha'], float)
+            assert kwargs['alpha'] > 0.0
 
 def test_lrt_collinear_df_is_zero(test_ctx):
     with temp_workspace():


### PR DESCRIPTION
## Summary
- Ensure LRT follow-up tasks submit outside the error callback
- Use scalar ridge penalties and batched leverage calculation for stability
- Add shared-memory to memmap fallback and robust column index resolution
- Update ridge penalty test to expect scalar alpha

## Testing
- `python -m py_compile iox.py models.py pipes.py`
- `pytest tests.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c22179f2e8832eaf2a3591d0449ef7