### PR TITLE
Improve memory accounting and progress tracking

### DIFF
--- a/phewas/iox.py
+++ b/phewas/iox.py
@@ -466,7 +466,7 @@ def load_pheno_cases_from_cache(name, cache_dir, cdr_codename):
     path = os.path.join(cache_dir, f"pheno_{name}_{cdr_codename}.parquet")
     if not os.path.exists(path):
         return pd.Index([], dtype=str)
-    df = pd.read_parquet(path)
+    df = pd.read_parquet(path, columns=['is_case'])
     if df.index.name != 'person_id':
         if 'person_id' in df.columns:
             df = df.set_index('person_id')


### PR DESCRIPTION
## Summary
- prevent BudgetManager.revise from crashing on missing inversion ids and add global progress registry
- reserve shared-memory tokens for LRT stages and adapt worker pool size based on observed footprints
- throttle phenotype fetcher concurrency, skip rewriting cached files, and clean shared-memory handles on worker exit
- carry dataset codename through phenotype tasks and log budget after admitting inversions

## Testing
- `./test_setup.sh`
- `pytest tests.py` *(fails: DefaultCredentialsError, Master CSV file was not created)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e37704e4832ea27d4ef5a3479b47