### PR TITLE
Use TSV inversion info and CSV summary outputs

### DIFF
--- a/stats/af_pi.py
+++ b/stats/af_pi.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 
 # --- Configuration ---
-INV_INFO_FILE = "inv_info.csv"
+INV_INFO_FILE = "inv_info.tsv"
 STATS_FILE = "output.csv"
 
 # Columns to use (Reduced)
@@ -169,11 +169,11 @@ def main():
             with open(INV_INFO_FILE, 'r', encoding='utf-8') as f:
                 content = f.read()
                 if content.startswith('\ufeff'): content = content[1:]
-            df_inv = pd.read_csv(io.StringIO(content), usecols=INV_COLS)
+            df_inv = pd.read_csv(io.StringIO(content), sep='\t', usecols=INV_COLS)
         except UnicodeDecodeError:
              logger.warning(f"UTF-8 decoding failed for {INV_INFO_FILE}. Trying latin-1.")
              with open(INV_INFO_FILE, 'r', encoding='latin-1') as f: content = f.read()
-             df_inv = pd.read_csv(io.StringIO(content), usecols=INV_COLS)
+             df_inv = pd.read_csv(io.StringIO(content), sep='\t', usecols=INV_COLS)
 
         logger.info(f"Loaded {len(df_inv)} rows from {INV_INFO_FILE}")
         df_inv = df_inv.rename(columns=INV_RENAME)

--- a/stats/category_per_site.py
+++ b/stats/category_per_site.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 # ---------- Files ----------
 INV_FILE   = Path("inv_info.tsv")                 # required
-SUMMARY    = Path("output.tsv")                   # required
+SUMMARY    = Path("output.csv")                   # required
 PI_FALSTA  = Path("per_site_diversity_output.falsta")
 FST_FALSTA = Path("per_site_fst_output.falsta")
 
@@ -103,9 +103,9 @@ def load_inversions(inv_path: Path) -> pd.DataFrame:
 def load_summary(sum_path: Path) -> pd.DataFrame:
     if not sum_path.is_file():
         raise FileNotFoundError(f"Required summary file not found: {sum_path}")
-    dbg("Loading per-region summary from output.tsv ...")
-    df = pd.read_csv(sum_path, sep="\t", dtype=str)
-    dbg(f"output.tsv columns: {list(df.columns)}")
+    dbg("Loading per-region summary from output.csv ...")
+    df = pd.read_csv(sum_path, dtype=str)
+    dbg(f"output.csv columns: {list(df.columns)}")
 
     need = ["chr","region_start","region_end",
             "0_pi_filtered","1_pi_filtered",
@@ -113,7 +113,7 @@ def load_summary(sum_path: Path) -> pd.DataFrame:
             "hudson_fst_hap_group_0v1"]
     miss = [c for c in need if c not in df.columns]
     if miss:
-        raise RuntimeError(f"output.tsv missing required columns: {miss}")
+        raise RuntimeError(f"output.csv missing required columns: {miss}")
 
     out = pd.DataFrame({
         "chr": df["chr"].map(norm_chr),
@@ -130,8 +130,8 @@ def load_summary(sum_path: Path) -> pd.DataFrame:
     out["start"] = out["start"].astype(int)
     out["end"]   = out["end"].astype(int)
     kept = len(out)
-    dbg(f"output.tsv rows retained: {kept} (dropped {before-kept} with missing keys)")
-    dbg("First 3 normalized rows from output.tsv:\n" + str(out[["chr","start","end"]].head(3).to_string(index=False)))
+    dbg(f"output.csv rows retained: {kept} (dropped {before-kept} with missing keys)")
+    dbg("First 3 normalized rows from output.csv:\n" + str(out[["chr","start","end"]].head(3).to_string(index=False)))
     return out
 
 # ---------- 3) Strict region↔inversion matching (±1 on region side; crash on >1 match) ----------

--- a/stats/conserve_chords.py
+++ b/stats/conserve_chords.py
@@ -31,7 +31,7 @@ logger.info("--- Starting New Script Run (Node Avg Color, Blue-Red CMap 0-1, Sep
 
 # File paths
 PAIRWISE_FILE = 'all_pairwise_results.csv'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 timestamp = time.strftime("%Y%m%d-%H%M%S")
 OUTPUT_DIR = f'chord_plots_node_avg_color_{timestamp}'
 RECURRENT_CHORD_PLOT_FILE = os.path.join(OUTPUT_DIR, 'recurrent_chord_node_avg.html')
@@ -640,7 +640,7 @@ def main():
         logger.info(f"Loading pairwise data from: {PAIRWISE_FILE}")
         pairwise_df = pd.read_csv(PAIRWISE_FILE); logger.info(f"Loaded {len(pairwise_df):,} rows.")
         logger.info(f"Loading inversion info from: {INVERSION_FILE}")
-        inversion_df = pd.read_csv(INVERSION_FILE); logger.info(f"Loaded {len(inversion_df):,} rows.")
+        inversion_df = pd.read_csv(INVERSION_FILE, sep='\t'); logger.info(f"Loaded {len(inversion_df):,} rows.")
     except FileNotFoundError as e:
         logger.error(f"Error loading input file: {e}. ABORTING."); return
     except Exception as e:

--- a/stats/cross_violins.py
+++ b/stats/cross_violins.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('inversion_omega_analysis')
 
 # --- File Paths & Constants ---
 PAIRWISE_FILE = Path('all_pairwise_results.csv')
-INVERSION_FILE = Path('inv_info.csv')
+INVERSION_FILE = Path('inv_info.tsv')
 OUTPUT_PLOT_PATH = Path('inversion_omega_analysis_plot_median_only.png')
 
 # --- Plotting Style ---
@@ -49,7 +49,7 @@ def load_and_prepare_data():
 
     try:
         pairwise_df = pd.read_csv(PAIRWISE_FILE)
-        inversion_df = pd.read_csv(INVERSION_FILE)
+        inversion_df = pd.read_csv(INVERSION_FILE, sep='\t')
         logger.info(f"Loaded {len(pairwise_df)} pairwise results and {len(inversion_df)} inversion records.")
     except FileNotFoundError:
         logger.error(f"Input file not found. Ensure '{PAIRWISE_FILE}' and '{INVERSION_FILE}' exist.")

--- a/stats/dist_diversity_by_type.py
+++ b/stats/dist_diversity_by_type.py
@@ -40,7 +40,7 @@ BAR_ALPHA = 0.3      # Transparency for plot bars (Used previously, kept for ref
 
 # File paths (Update these paths if necessary)
 PI_DATA_FILE = 'per_site_output.falsta'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 OUTPUT_DIR = Path('pi_analysis_results_filtered_pi_length') #  output directory name
 
 # Create output directory if it doesn't exist
@@ -1212,7 +1212,7 @@ def main():
         return
     logger.info(f"Loading inversion info from {inv_file_path}")
     try:
-        inversion_df = pd.read_csv(inv_file_path)
+        inversion_df = pd.read_csv(inv_file_path, sep='\t')
         logger.info(f"Loaded {inversion_df.shape[0]} rows from inversion file.")
         recurrent_regions, single_event_regions = map_regions_to_inversions(inversion_df)
     except Exception as e:

--- a/stats/dist_fst_by_type.py
+++ b/stats/dist_fst_by_type.py
@@ -34,7 +34,7 @@ FLANK_SIZE = 100_000
 
 # File paths
 FST_DATA_FILE = 'per_site_fst_output.falsta'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 OUTPUT_PLOT = 'fst_flanking_regions_bar_plot.png'
 
 # Adjusted category mapping to only include relevant categories
@@ -246,7 +246,7 @@ def create_bar_plot(categories):
 def main():
     start_time = time.time()
     logger.info("Starting fst flanking regions analysis...")
-    inversion_df = pd.read_csv(INVERSION_FILE)
+    inversion_df = pd.read_csv(INVERSION_FILE, sep='\t')
     recurrent_regions, single_event_regions = map_regions_to_inversions(inversion_df)
     fst_sequences = load_fst_data(FST_DATA_FILE)
     flanking_means = calculate_flanking_means(fst_sequences)

--- a/stats/dnds_kde.py
+++ b/stats/dnds_kde.py
@@ -20,7 +20,7 @@ logger = logging.getLogger('median_omega_analysis_standalone')
 
 # File paths
 PAIRWISE_FILE = Path('all_pairwise_results.csv')
-INVERSION_FILE = Path('inv_info.csv')
+INVERSION_FILE = Path('inv_info.tsv')
 OUTPUT_PLOT_PATH = Path('median_omega_distribution_standalone.png')
 
 # Plotting Style Adjustments
@@ -63,7 +63,7 @@ def load_input_files():
             logger.error(f"Inversion info file not found: {INVERSION_FILE}")
             return None, None
         logger.info(f"Loading inversion info from {INVERSION_FILE}")
-        inversion_df = pd.read_csv(INVERSION_FILE)
+        inversion_df = pd.read_csv(INVERSION_FILE, sep='\t')
 
         logger.info(f"Pairwise results: {pairwise_df.shape[0]} rows, {pairwise_df.shape[1]} columns")
         logger.info(f"Inversion info: {inversion_df.shape[0]} rows, {inversion_df.shape[1]} columns")

--- a/stats/estimators_fst.py
+++ b/stats/estimators_fst.py
@@ -11,7 +11,7 @@ import seaborn as sns
 
 # Input Files
 SUMMARY_STATS_FILE = 'output.csv'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 
 # Output Files
 FST_SCATTER_PLOT_FILENAME = 'fst_wc_vs_hudson_colored_by_inversion_type.png'
@@ -289,7 +289,7 @@ def main():
     ))
 
     try:
-        inv_df = pd.read_csv(INVERSION_FILE, usecols=INVERSION_FILE_COLUMNS)
+        inv_df = pd.read_csv(INVERSION_FILE, sep='\t', usecols=INVERSION_FILE_COLUMNS)
         sum_df_raw = pd.read_csv(SUMMARY_STATS_FILE)
         missing_cols = [col for col in summary_cols_to_load if col not in sum_df_raw.columns]
         if missing_cols:

--- a/stats/fst_violins.py
+++ b/stats/fst_violins.py
@@ -9,7 +9,7 @@ from matplotlib.patches import PathPatch
 from scipy.stats import mannwhitneyu
 
 SUMMARY_STATS_FILE = 'output.csv'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 COORDINATE_MAP_FILE = 'map.tsv'
 
 SUMMARY_STATS_COORDINATE_COLUMNS = {'chr': 'chr', 'start': 'region_start', 'end': 'region_end'}
@@ -67,7 +67,7 @@ def load_required_inputs():
     if not os.path.exists(SUMMARY_STATS_FILE):
         log.critical(f"Required summary file '{SUMMARY_STATS_FILE}' not found.")
         sys.exit(1)
-    inv_df = pd.read_csv(INVERSION_FILE, usecols=lambda c: c in INVERSION_FILE_COLUMNS)
+    inv_df = pd.read_csv(INVERSION_FILE, sep='\t', usecols=lambda c: c in INVERSION_FILE_COLUMNS)
     sum_cols = list(SUMMARY_STATS_COORDINATE_COLUMNS.values()) + [HUDSON_FST_COL]
     sum_df = pd.read_csv(SUMMARY_STATS_FILE, usecols=lambda c: c in sum_cols)
     miss = [c for c in SUMMARY_STATS_COORDINATE_COLUMNS.values() if c not in sum_df.columns]

--- a/stats/inv_dir_recur.py
+++ b/stats/inv_dir_recur.py
@@ -23,7 +23,7 @@ from scipy.stats import wilcoxon, mannwhitneyu
 # Contains pi values per orientation (e.g., 0_pi_filtered, 1_pi_filtered)
 OUTPUT_PI_PATH = 'output.csv'
 # Contains recurrence info per region (e.g., 0_single_1_recur)
-INV_INFO_PATH = 'inv_info.csv'
+INV_INFO_PATH = 'inv_info.tsv'
 # Contains phased genotypes (e.g., 0|1) for inversions per sample
 GENOTYPE_FILE = 'variants_freeze4inv_sv_inv_hg38_processed_arbigent_filtered_manualDotplot_filtered_PAVgenAdded_withInvCategs_syncWithWH.fixedPH.simpleINV.mod.tsv'
 # Folder containing PCA results per chromosome
@@ -182,7 +182,7 @@ try:
     output_df = pd.read_csv(OUTPUT_PI_PATH)
     logger.info(f"Loaded {len(output_df)} rows from Pi data: {OUTPUT_PI_PATH}")
 
-    inv_info_df = pd.read_csv(INV_INFO_PATH)
+    inv_info_df = pd.read_csv(INV_INFO_PATH, sep='\t')
     logger.info(f"Loaded {len(inv_info_df)} rows from Inversion Info: {INV_INFO_PATH}")
 
     geno_df = pd.read_csv(GENOTYPE_FILE, sep='\t')
@@ -240,7 +240,7 @@ output_df['region_end'] = pd.to_numeric(output_df['region_end'], errors='coerce'
 output_df.dropna(subset=['chr', 'region_start', 'region_end'], inplace=True)
 
 
-# B. Standardize Inversion Info Data ('inv_info.csv')
+# B. Standardize Inversion Info Data ('inv_info.tsv')
 recur_col = None
 coord_cols_inv = []
 chr_col_inv = None

--- a/stats/inv_dir_recur_violins.py
+++ b/stats/inv_dir_recur_violins.py
@@ -16,7 +16,7 @@ SCIPY_OK = True
 # -----------------------------------------------------------------------------
 # Configuration / aesthetics
 # -----------------------------------------------------------------------------
-OUTPUT_TSV = Path("./output.tsv")
+OUTPUT_CSV = Path("./output.csv")
 INVINFO_TSV = Path("./inv_info.tsv")
 
 rng = np.random.default_rng(2025)  # reproducible jitter
@@ -93,14 +93,14 @@ def _sci_notation_tex(p):
     exp_sup = str(exp).translate(superscripts)
     return f"{mant_str}×10{exp_sup}"
 
-def _load_and_match(output_tsv: Path, invinfo_tsv: Path) -> pd.DataFrame:
-    """Load TSV/CSV files and match regions with ±1 bp tolerance on start/end."""
-    if not output_tsv.exists():
-        raise FileNotFoundError(f"Cannot find {output_tsv.resolve()}")
+def _load_and_match(output_csv: Path, invinfo_tsv: Path) -> pd.DataFrame:
+    """Load CSV/TSV files and match regions with ±1 bp tolerance on start/end."""
+    if not output_csv.exists():
+        raise FileNotFoundError(f"Cannot find {output_csv.resolve()}")
     if not invinfo_tsv.exists():
         raise FileNotFoundError(f"Cannot find {invinfo_tsv.resolve()}")
 
-    df  = pd.read_csv(output_tsv, sep="\t")
+    df  = pd.read_csv(output_csv)
     inv = pd.read_csv(invinfo_tsv, sep="\t")
 
     # Standardize chromosomes
@@ -128,7 +128,7 @@ def _load_and_match(output_tsv: Path, invinfo_tsv: Path) -> pd.DataFrame:
             recur_col = c
             break
     if recur_col is None:
-        raise KeyError("inv_info.csv lacks '0_single_1_recur_consensus' and '0_single_1_recur'.")
+        raise KeyError("inv_info.tsv lacks '0_single_1_recur_consensus' and '0_single_1_recur'.")
 
     inv_small = inv[["chr_std", "Start", "End", recur_col]].copy()
     merged = df_cand.merge(inv_small, on=["chr_std", "Start", "End"], how="left")
@@ -348,7 +348,7 @@ def main():
     })
 
     # Load & match
-    matched = _load_and_match(OUTPUT_TSV, INVINFO_TSV)
+    matched = _load_and_match(OUTPUT_CSV, INVINFO_TSV)
     if matched.empty:
         raise SystemExit("No matched regions found with ±1 bp tolerance.")
 

--- a/stats/length_distribution.py
+++ b/stats/length_distribution.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 def main():
     # Load the CSV data and compute the length of each region.
-    df = pd.read_csv("inv_info.csv")
+    df = pd.read_csv("inv_info.tsv", sep='\t')
     df['length'] = df['region_end'] - df['region_start']
     
     # Sort by region length and print the chromosome and coordinates of the 10 smallest regions.

--- a/stats/manhattan_plot.py
+++ b/stats/manhattan_plot.py
@@ -60,7 +60,7 @@ def fuzzy_overlaps(data_start, data_end, inv_start, inv_end, tolerance=1):
     return overlap
 
 # --- Main Plotting Function ---
-def create_manhattan_plot(data_file, inv_file='inv_info.csv'):
+def create_manhattan_plot(data_file, inv_file='inv_info.tsv'):
     """Generates the multi-panel Manhattan-like plot."""
     print(f"\n--- Starting Plot Generation ---")
     print(f"Reading main data from: {data_file}")
@@ -167,7 +167,7 @@ def create_manhattan_plot(data_file, inv_file='inv_info.csv'):
     inv_df = pd.DataFrame(columns=inv_internal_cols + [inv_recur_col_internal])
 
     try:
-        inv_df_raw = pd.read_csv(inv_file)
+        inv_df_raw = pd.read_csv(inv_file, sep='\t')
         print(f"Read inversion file {inv_file}, shape: {inv_df_raw.shape}")
 
         if all(col in inv_df_raw.columns for col in inv_raw_cols):
@@ -495,7 +495,7 @@ def create_manhattan_plot(data_file, inv_file='inv_info.csv'):
 def main():
     """Sets up file paths and calls the plotting function."""
     data_file = RESULTS_DIR / 'final_results.csv'
-    inv_file = 'inv_info.csv'
+    inv_file = 'inv_info.tsv'
 
     if not data_file.exists():
         print(f"ERROR: Main data file not found: {data_file}")

--- a/stats/num_events_diversity.py
+++ b/stats/num_events_diversity.py
@@ -19,7 +19,7 @@ framework under these specific N=1 conditions can be hard to interpret.
 
 # --- Configuration ---
 PI_DATA_PATH = 'output.csv'        # Pi values per orientation (0_pi_filtered, 1_pi_filtered)
-INV_INFO_PATH = 'inv_info.csv'     # Inversion info (Recurrence, Num events string, coords)
+INV_INFO_PATH = 'inv_info.tsv'     # Inversion info (Recurrence, Num events string, coords)
 OUTPUT_DIR = 'recurrent_events_analysis_separate_v2' # Directory for analysis results
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
@@ -62,7 +62,7 @@ def main():
     print(f"Loading data from {PI_DATA_PATH} and {INV_INFO_PATH}...")
     try:
         pi_data = pd.read_csv(PI_DATA_PATH)
-        inv_info = pd.read_csv(INV_INFO_PATH)
+        inv_info = pd.read_csv(INV_INFO_PATH, sep='\t')
     except FileNotFoundError as e:
         print(f"ERROR: Input file not found: {e}. Exiting.")
         exit(1)

--- a/stats/overall_fst_by_type.py
+++ b/stats/overall_fst_by_type.py
@@ -13,7 +13,7 @@ import os
 
 # Input Files
 SUMMARY_STATS_FILE = 'output.csv'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 COORDINATE_MAP_FILE = 'map.tsv' # New configuration for the map file
 
 # Output File Templates
@@ -728,7 +728,7 @@ def main():
         logger.critical(f"CRITICAL: Summary stats file '{SUMMARY_STATS_FILE}' not found. Exiting.")
         sys.exit(1)
 
-    inv_df = pd.read_csv(INVERSION_FILE, usecols=lambda c: c in INVERSION_FILE_COLUMNS)
+    inv_df = pd.read_csv(INVERSION_FILE, sep='\t', usecols=lambda c: c in INVERSION_FILE_COLUMNS)
     sum_df = pd.read_csv(SUMMARY_STATS_FILE, usecols=lambda c: c in sum_cols_load)
     
     logger.info(f"Loaded data. Summary ('{SUMMARY_STATS_FILE}'): {len(sum_df)} rows. Inversion ('{INVERSION_FILE}'): {len(inv_df)} rows.")

--- a/stats/overall_groups_dnds.py
+++ b/stats/overall_groups_dnds.py
@@ -25,7 +25,7 @@ warnings.filterwarnings('ignore', category=pd.errors.PerformanceWarning)
 RESULTS_DIR = Path("results")
 PLOTS_DIR = Path("plots")
 RAW_DATA_FILE = 'all_pairwise_results.csv'
-INV_INFO_FILE = 'inv_info.csv'
+INV_INFO_FILE = 'inv_info.tsv'
 
 # Analysis Parameters
 MIN_SAMPLES_FOR_TEST = 5  # Minimum data points per group for statistical tests
@@ -127,7 +127,7 @@ def load_and_prepare_data() -> Optional[pd.DataFrame]:
     print("--- 1. Loading and Preparing Data ---")
     try:
         # Load and process inversion info
-        inv_df = pd.read_csv(INV_INFO_FILE)
+        inv_df = pd.read_csv(INV_INFO_FILE, sep='\t')
         inv_df.rename(columns={'Chromosome': 'chr', 'Start': 'inv_start', 'End': 'inv_end'}, inplace=True)
         inv_df['chr'] = inv_df['chr'].astype(str).apply(lambda x: x if x.startswith('chr') else 'chr' + x)
         inv_df.dropna(subset=['chr', 'inv_start', 'inv_end'], inplace=True)

--- a/stats/pairwise_matrix_test.py
+++ b/stats/pairwise_matrix_test.py
@@ -171,8 +171,8 @@ def read_and_preprocess_data(file_path):
     print(f"Unique coordinates found: {df.groupby(['chrom', 'start', 'end']).ngroups}")
     print(f"Unique chromosomes found: {df['chromosome'].nunique()}")
 
-    # Load the inversion info CSV
-    inv_info_df = pd.read_csv('inv_info.csv')
+    # Load the inversion info TSV
+    inv_info_df = pd.read_csv('inv_info.tsv', sep='\t')
 
 
     # Summarize comparison counts by the new grouping scheme

--- a/stats/recur_conservation.py
+++ b/stats/recur_conservation.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('conservation_analysis_detailed')
 
 # File paths
 PAIRWISE_FILE = 'all_pairwise_results.csv'
-INVERSION_FILE = 'inv_info.csv'
+INVERSION_FILE = 'inv_info.tsv'
 OUTPUT_RESULTS_LOO_GENE_PROPORTION = 'leave_one_out_gene_proportion_results.csv' # Output name
 
 # --- Helper Functions ---
@@ -918,7 +918,7 @@ def main():
         logger.info(f"  Loaded {len(pairwise_df):,} rows from {PAIRWISE_FILE}.")
 
         logger.info(f"Loading inversion info from: {INVERSION_FILE}")
-        inversion_df = pd.read_csv(INVERSION_FILE)
+        inversion_df = pd.read_csv(INVERSION_FILE, sep='\t')
         logger.info(f"  Loaded {len(inversion_df):,} rows (inversions) from {INVERSION_FILE}.")
         # Display head of inversion data for context
         logger.info(f"  Inversion data columns: {inversion_df.columns.tolist()}")

--- a/stats/recur_diversity.py
+++ b/stats/recur_diversity.py
@@ -8,7 +8,7 @@ warnings.filterwarnings('ignore')
 
 # Load both data files
 output_path = 'output.csv'
-inv_info_path = 'inv_info.csv'
+inv_info_path = 'inv_info.tsv'
 
 # Load output.csv
 output_data = pd.read_csv(output_path)
@@ -16,9 +16,9 @@ print(f"Loaded {len(output_data)} rows from output.csv")
 print("Output data chromosome format examples:")
 print(output_data['chr'].head().tolist())
 
-# Load inv_info.csv
-inv_info = pd.read_csv(inv_info_path)
-print(f"Loaded {len(inv_info)} rows from inv_info.csv")
+# Load inv_info.tsv
+inv_info = pd.read_csv(inv_info_path, sep='\t')
+print(f"Loaded {len(inv_info)} rows from inv_info.tsv")
 
 # Rename columns to match expected format
 inv_info = inv_info.rename(columns={

--- a/stats/region_descriptive.py
+++ b/stats/region_descriptive.py
@@ -3,16 +3,16 @@ import numpy as np
 import io
 import os
 
-def calculate_inversion_stats(input_filename="inv_info.csv", output_filename="inversion_stats.csv"):
+def calculate_inversion_stats(input_filename="inv_info.tsv", output_filename="inversion_stats.csv"):
     """
-    Reads inversion data from the input CSV file, calculates descriptive
+    Reads inversion data from the input TSV file, calculates descriptive
     statistics (mean and standard deviation) for frequency, size, and
     flanking repeat identity, grouped by recurrence status (excluding Y
     chromosome), and saves the results to the specified output CSV file
     with human-readable headers (using spaces).
 
     Args:
-        input_filename (str): The path to the input CSV file (e.g., "inv_info.csv").
+        input_filename (str): The path to the input TSV file (e.g., "inv_info.tsv").
         output_filename (str): The path to save the output CSV file (e.g., "inversion_stats.csv").
 
     Returns:
@@ -30,7 +30,7 @@ def calculate_inversion_stats(input_filename="inv_info.csv", output_filename="in
             first_line = csvfile.readline()
             if first_line.startswith('\ufeff'): # Handle BOM
                 first_line = first_line[1:]
-            header = [h.strip() for h in first_line.strip().split(',')]
+            header = [h.strip() for h in first_line.strip().split('\t')]
 
             # --- Identify column indices robustly ---
             column_mapping = {
@@ -58,9 +58,9 @@ def calculate_inversion_stats(input_filename="inv_info.csv", output_filename="in
 
 
             if missing_cols:
-                return f"Error: Missing expected column(s) in CSV header: {', '.join(missing_cols)}"
+                return f"Error: Missing expected column(s) in TSV header: {', '.join(missing_cols)}"
 
-            reader = csv.reader(csvfile)
+            reader = csv.reader(csvfile, delimiter='\t')
 
             for row in reader:
                 if not row: continue
@@ -184,5 +184,5 @@ def calculate_inversion_stats(input_filename="inv_info.csv", output_filename="in
 
 # --- Main execution block ---
 if __name__ == "__main__":
-    result_message = calculate_inversion_stats("inv_info.csv", "inversion_stats.csv")
+    result_message = calculate_inversion_stats("inv_info.tsv", "inversion_stats.csv")
     print(result_message)


### PR DESCRIPTION
## Summary
- Replace `inv_info.csv` references with tab-separated `inv_info.tsv`
- Switch `output.tsv` to comma-separated `output.csv`
- Update all affected stats scripts to parse using the correct delimiters

## Testing
- `python -m py_compile stats/af_pi.py stats/category_per_site.py stats/conserve_chords.py stats/cross_violins.py stats/dist_diversity_by_type.py stats/dist_fst_by_type.py stats/dnds_kde.py stats/estimators_fst.py stats/fst_violins.py stats/inv_dir_recur.py stats/inv_dir_recur_model.py stats/inv_dir_recur_violins.py stats/length_distribution.py stats/manhattan_plot.py stats/num_events_diversity.py stats/overall_fst_by_type.py stats/overall_groups_dnds.py stats/pairwise_matrix_test.py stats/recur_conservation.py stats/recur_diversity.py stats/region_descriptive.py`


------
https://chatgpt.com/codex/tasks/task_e_68c455e9db34832eb7981683d2100696