### PR TITLE
Ensure stats PDF outputs use TrueType fonts

### DIFF
--- a/stats/category_per_site.py
+++ b/stats/category_per_site.py
@@ -65,6 +65,8 @@ AX_TEXT        = "#333333"   # labels/ticks
 mpl.rcParams.update({
     "font.family": "sans-serif",
     "font.sans-serif": ["DejaVu Sans", "Noto Sans", "Liberation Sans", "Ubuntu", "Arial"],
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
     "mathtext.fontset": "dejavusans",
     "axes.spines.top": False,
     "axes.spines.right": False,

--- a/stats/events_rate_diversity.py
+++ b/stats/events_rate_diversity.py
@@ -58,7 +58,9 @@ plt.rcParams.update({
     "grid.linestyle": "--",
     "axes.spines.top": False,
     "axes.spines.right": False,
-    "legend.frameon": False
+    "legend.frameon": False,
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
 })
 
 # ------------------------- HELPERS ---------------------------

--- a/stats/fst_violins.py
+++ b/stats/fst_violins.py
@@ -39,6 +39,8 @@ DPI = 350
 OUTPUT_PDF = 'hudson_fst.pdf'
 
 plt.rcParams['hatch.linewidth'] = 0.18
+plt.rcParams['pdf.fonttype'] = 42
+plt.rcParams['ps.fonttype'] = 42
 
 logging.basicConfig(
     level=logging.INFO,

--- a/stats/inv_dir_recur_violins.py
+++ b/stats/inv_dir_recur_violins.py
@@ -336,6 +336,8 @@ def main():
     mpl.rcParams.update({
         "font.family": "sans-serif",
         "font.sans-serif": ["DejaVu Sans", "Noto Sans", "Liberation Sans", "Ubuntu", "Arial"],
+        "pdf.fonttype": 42,
+        "ps.fonttype": 42,
         "mathtext.fontset": "dejavusans",
         "axes.spines.top": False,
         "axes.spines.right": False,

--- a/stats/manhattan_phe.py
+++ b/stats/manhattan_phe.py
@@ -65,6 +65,8 @@ plt.rcParams.update({
     "grid.linewidth": 0.55,
     "grid.alpha": 0.6,
     "legend.frameon": False,
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
 })
 
 # ---------- Helpers ----------

--- a/stats/volcano.py
+++ b/stats/volcano.py
@@ -28,6 +28,8 @@ plt.rcParams.update({
     "grid.linestyle": ":",
     "grid.linewidth": 0.55,
     "grid.alpha": 0.6,
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
 })
 
 # --------------------------- Color / markers ---------------------------


### PR DESCRIPTION
## Summary
- configure Matplotlib to embed Type 42 fonts in each stats plotting script that writes PDF output so saved figures retain editable text.

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68c8ddcad994832e86fd57c20cbeb6b7