### PR TITLE
Remove redundant reassignment in batch phenotype fetch

### DIFF
--- a/phewas/pheno.py
+++ b/phewas/pheno.py
@@ -496,8 +496,6 @@ def _query_batch_bq(batch_infos, bq_client, cdr_id, core_index, cache_dir, cdr_c
         print(f"[Fetcher]  - [Batch] Skipping '{s_name}', another process has the lock.", flush=True)
 
     batch_infos = filtered_infos
-
-    batch_infos = filtered_infos
     try:
         codes_list = []
         phenos_list = []


### PR DESCRIPTION
## Summary
- remove the duplicate reassignment of `batch_infos` in `_query_batch_bq`

## Testing
- `bash test_setup.sh`
- `python3 tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68c996378620832eaa60b05f67f25c14