### PR TITLE
Fix OpenBLAS target detection for powerpc64le cross builds

### DIFF
--- a/vendor/openblas-build/src/build.rs
+++ b/vendor/openblas-build/src/build.rs
@@ -321,6 +321,7 @@ impl Target {
             "armv5te" => Some(Target::ARMV5),
             "armv6" => Some(Target::ARMV6),
             "armv7" => Some(Target::ARMV7),
+            "powerpc64" | "powerpc64le" => Some(Target::POWER8),
             "loongarch64" => Some(Target::LOONGSONGENERIC),
             "mips64" => Some(Target::MIPS64_GENERIC),
             "mips64el" => Some(Target::MIPS64_GENERIC),


### PR DESCRIPTION
## Summary
- add automatic POWER8 selection when cross compiling to powerpc64 or powerpc64le so OpenBLAS builds without manual configuration

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68c9af18b598832eb176d33fb3843c61