### PR TITLE
Use faer backend for efficient_pca

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = "1.21.3"
 terminal_size = "0.4.2"
 chrono = "0.4.41"
 glob = "0.3.2"
-efficient_pca = "0.1.4"
+efficient_pca = { version = "*", default-features = false, features = ["backend_faer"] }
 ndarray = "0.16.1"
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9.109", features = ["vendored"] }
@@ -50,7 +50,7 @@ openssl-sys = { version = "0.9.109", features = ["vendored"] }
 
 [patch.crates-io]
 openblas-build = { path = "vendor/openblas-build" }
-efficient_pca = { path = "vendor/efficient_pca" }
+efficient_pca = { git = "https://github.com/SauersML/efficient_pca", rev = "0c80fad462c3913ea76f3494e8c254fa9cd221f3" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## Summary
- disable the OpenBLAS build by switching efficient_pca to the faer backend
- override the efficient_pca crate to a git revision that provides the backend feature

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68ca043c6cc4832ebdf1f8ccda065461