### PR TITLE
Fix apt dependencies in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
               yum install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
             elif command -v apt-get >/dev/null 2>&1; then
               apt-get update
-              apt-get install -y build-essential gfortran perl libipc-cmd-perl wget
+              apt-get install -y build-essential gfortran perl wget
             elif command -v apk >/dev/null 2>&1; then
               apk add --no-cache build-base gfortran perl perl-utils wget
             fi
@@ -121,7 +121,7 @@ jobs:
               yum install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
             elif command -v apt-get >/dev/null 2>&1; then
               apt-get update
-              apt-get install -y build-essential gfortran perl libipc-cmd-perl wget
+              apt-get install -y build-essential gfortran perl wget
             elif command -v apk >/dev/null 2>&1; then
               apk add --no-cache build-base gfortran perl perl-utils wget
             fi


### PR DESCRIPTION
## Summary
- update the Linux build scripts in the CI workflow to avoid requesting the unavailable libipc-cmd-perl package on apt-based images
- keep the IPC::Cmd bootstrap step so the module is still installed when missing

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ca35ce06f0832ebf0259b3b000a10d