### PR TITLE
Work around s390x OpenSSL assembly for Linux CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Work around missing s390x assembler support
+        if: ${{ matrix.platform.target == 's390x' }}
+        run: echo "OPENSSL_NO_ASM=1" >> $GITHUB_ENV
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
## Summary
- add a Linux CI step to disable OpenSSL assembly when building the s390x wheel to avoid unsupported assembler instructions

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca45095148832e9b92f8a43a08ddd7