### PR TITLE
Fix OpenSSL build on s390x CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,9 @@ jobs:
           python-version: 3.x
       - name: Work around missing s390x assembler support
         if: ${{ matrix.platform.target == 's390x' }}
-        run: echo "OPENSSL_NO_ASM=1" >> $GITHUB_ENV
+        run: |
+          echo "OPENSSL_NO_ASM=1" >> $GITHUB_ENV
+          echo "OPENSSL_SRC_CONFIGURE_ARGS=no-asm" >> $GITHUB_ENV
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
## Summary
- extend the s390x workaround to pass `OPENSSL_SRC_CONFIGURE_ARGS=no-asm`
- ensure the vendored OpenSSL build disables assembly so the build no longer fails on missing instructions

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68caeb54f4f4832e84f661cec0e49c24