### PR TITLE
Disable OpenSSL asm on s390x

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,6 @@
 SSL_CERT_FILE = { value = "/etc/ssl/certs/ca-certificates.crt", force = true }
 SSL_CERT_DIR = { value = "/etc/ssl/certs", force = true }
 OPENSSL_NO_PKG_CONFIG = { value = "1", force = true }
+
+[target.s390x-unknown-linux-gnu.env]
+OPENSSL_NO_ASM = { value = "1", force = true }


### PR DESCRIPTION
## Summary
- disable OpenSSL assembly when targeting s390x so the vendored OpenSSL build no longer uses unsupported instructions

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68cb3c6a76d0832e84398d3dd2125771