### PR TITLE
Add boot overall cache dir to test context

### DIFF
--- a/phewas/tests.py
+++ b/phewas/tests.py
@@ -199,6 +199,7 @@ def test_ctx():
         "RESULTS_CACHE_DIR": "./phewas_cache/results_atomic",
         "LRT_OVERALL_CACHE_DIR": "./phewas_cache/lrt_overall",
         "LRT_FOLLOWUP_CACHE_DIR": "./phewas_cache/lrt_followup",
+        "BOOT_OVERALL_CACHE_DIR": "./phewas_cache/boot_overall",
         "RIDGE_L2_BASE": 1.0,
         # Disable new filters for tests by default.
         # We will override these in specific tests that check the filters.


### PR DESCRIPTION
## Summary
- include the `BOOT_OVERALL_CACHE_DIR` entry in the shared `test_ctx` fixture so worker initialization sees the required context key

## Testing
- python3 tests.py
- python3 -m pytest tests.py

------
https://chatgpt.com/codex/tasks/task_e_68cb3ca9264c832eb49448e03331d2ac