### PR TITLE
Remove s390x build from Linux CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,6 @@ jobs:
             target: armv7
             openblas_target: ARMV7
           - runner: ubuntu-22.04
-            target: s390x
-            openblas_target: ZARCH_GENERIC
-          - runner: ubuntu-22.04
             target: ppc64le
             openblas_target: POWER9
     steps:


### PR DESCRIPTION
## Summary
- remove the s390x Linux target from the GitHub Actions CI matrix

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68cb48c04330832e8b624ad47100c297