### PR TITLE
Suppress LRT follow-up CIs for penalized fits

### DIFF
--- a/phewas/tests.py
+++ b/phewas/tests.py
@@ -199,6 +199,7 @@ def test_ctx():
         "RESULTS_CACHE_DIR": "./phewas_cache/results_atomic",
         "LRT_OVERALL_CACHE_DIR": "./phewas_cache/lrt_overall",
         "LRT_FOLLOWUP_CACHE_DIR": "./phewas_cache/lrt_followup",
+        "BOOT_OVERALL_CACHE_DIR": "./phewas_cache/boot_overall",
         "RIDGE_L2_BASE": 1.0,
         # Disable new filters for tests by default.
         # We will override these in specific tests that check the filters.


### PR DESCRIPTION
## Summary
- add guard thresholds to detect unusable confidence intervals from penalized follow-up fits
- coerce LRT rank calculations to operate on float64 arrays to avoid dtype errors
- drop ancestry CI output when penalization produces degenerate intervals while leaving valid ancestries untouched

## Testing
- python3 -m pytest tests.py
- python3 tests.py

------
https://chatgpt.com/codex/tasks/task_e_68cb3ca9264c832eb49448e03331d2ac