### PR TITLE
Expose PCA utilities in Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ interpreted from tuples like ``(sample_index, "L")`` or ``(sample_index, 1)``.
 | `ferromic.hudson_fst_with_sites(pop1, pop2, region)` | Tuple ``(HudsonFstResult, [HudsonFstSite, ...])``. |
 | `ferromic.wc_fst(variants, sample_names, sample_to_group, region)` | Weir & Cockerham FST with pairwise and per-site summaries. |
 | `ferromic.wc_fst_components(fst_estimate)` | Extract `(value, sum_a, sum_b, sites)` from any `FstEstimate`. |
+| `ferromic.chromosome_pca(variants, sample_names, n_components=10)` | Run PCA for a single chromosome and return a `ChromosomePcaResult`. |
+| `ferromic.chromosome_pca_to_file(variants, sample_names, chromosome, output_dir, n_components=10)` | Convenience helper that writes a TSV with PCA coordinates for one chromosome. |
+| `ferromic.per_chromosome_pca(variants_by_chromosome, sample_names, output_dir, n_components=10)` | Batch PCA analysis across chromosomes, emitting one TSV per chromosome. |
+| `ferromic.global_pca(variants_by_chromosome, sample_names, output_dir, n_components=10)` | Memory-efficient pipeline that runs per-chromosome PCA and produces a combined summary table. |
+| `ferromic.ChromosomePcaResult` | Light-weight container exposing `haplotype_labels`, `coordinates`, and `positions`. |
 | `ferromic.adjusted_sequence_length(start, end, allow=None, mask=None)` | Apply BED-style masks to a region length. |
 | `ferromic.inversion_allele_frequency(sample_map)` | Frequency of allele ``1`` across haplotypes. |
 
@@ -263,10 +268,14 @@ wc = ferromic.wc_fst(
     region=(990, 1_020),
 )
 
+pca_result = ferromic.chromosome_pca(variants, ["S0", "S1", "S2"], n_components=3)
+ferromic.chromosome_pca_to_file(variants, ["S0", "S1", "S2"], "2L", "./pca_outputs")
+
 print(f"π={pi:.6f}, θ={theta:.6f}")
 print(hudson)
 print(sites[0])
 print(wc.overall_fst)
+print(pca_result.coordinates[0][:3])
 ```
 
 The example demonstrates how the Python API mirrors Ferromic's Rust types while

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,17 @@
 //! native Python library while retaining Rust's performance.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyIterator, PyList, PyTuple};
 use pyo3::IntoPy;
 
+use crate::pca::{
+    compute_chromosome_pca, run_chromosome_pca_analysis, run_global_pca_analysis,
+    write_chromosome_pca_to_file, PcaResult,
+};
 use crate::process::{HaplotypeSide, QueryRegion, Variant, VcfError};
 use crate::stats::{
     calculate_adjusted_sequence_length, calculate_d_xy_hudson, calculate_fst_wc_haplotype_groups,
@@ -151,6 +156,49 @@ impl PairwiseDifference {
         format!(
             "PairwiseDifference(sample_i={}, sample_j={}, differences={}, comparable_sites={})",
             self.sample_i, self.sample_j, self.differences, self.comparable_sites
+        )
+    }
+}
+
+/// Principal component coordinates for a single chromosome.
+#[pyclass(module = "ferromic")]
+#[derive(Clone)]
+struct ChromosomePcaResult {
+    #[pyo3(get)]
+    haplotype_labels: Vec<String>,
+    #[pyo3(get)]
+    coordinates: Vec<Vec<f64>>,
+    #[pyo3(get)]
+    positions: Vec<i64>,
+}
+
+#[pymethods]
+impl ChromosomePcaResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "ChromosomePcaResult(haplotypes={}, components={}, variants={})",
+            self.haplotype_labels.len(),
+            self.coordinates.first().map(|row| row.len()).unwrap_or(0),
+            self.positions.len()
+        )
+    }
+}
+
+impl ChromosomePcaResult {
+    fn from_result(py: Python, result: &PcaResult) -> PyResult<Py<Self>> {
+        let coordinates = result
+            .pca_coordinates
+            .outer_iter()
+            .map(|row| row.to_vec())
+            .collect();
+
+        Py::new(
+            py,
+            ChromosomePcaResult {
+                haplotype_labels: result.haplotype_labels.clone(),
+                coordinates,
+                positions: result.positions.clone(),
+            },
         )
     }
 }
@@ -1042,6 +1090,26 @@ fn extract_sample_group_map(obj: &PyAny) -> PyResult<HashMap<String, (u8, u8)>> 
     Ok(map)
 }
 
+fn extract_variants_by_chromosome(obj: &PyAny) -> PyResult<HashMap<String, Vec<Variant>>> {
+    let dict = obj.downcast::<PyDict>().map_err(|_| {
+        PyValueError::new_err(
+            "variants_by_chromosome must be a dict mapping chromosome -> sequence of variants",
+        )
+    })?;
+
+    let mut map = HashMap::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        let chromosome = key.extract::<String>()?;
+        let variants: Vec<VariantInput> = value.extract()?;
+        map.insert(
+            chromosome,
+            variants.into_iter().map(VariantInput::into_inner).collect(),
+        );
+    }
+
+    Ok(map)
+}
+
 fn extract_interval_list(obj: Option<&PyAny>) -> PyResult<Option<Vec<(i64, i64)>>> {
     let Some(obj) = obj else { return Ok(None) };
     let mut intervals = Vec::new();
@@ -1268,6 +1336,125 @@ fn wc_fst_components_py(
     estimate.components()
 }
 
+/// Compute principal components for variants on a single chromosome.
+#[pyfunction(
+    name = "chromosome_pca",
+    signature = (variants, sample_names, n_components=10),
+    text_signature = "(variants, sample_names, n_components=10, /)"
+)]
+fn chromosome_pca_py(
+    py: Python,
+    variants: Vec<VariantInput>,
+    sample_names: Vec<String>,
+    n_components: usize,
+) -> PyResult<Py<ChromosomePcaResult>> {
+    if sample_names.is_empty() {
+        return Err(PyValueError::new_err(
+            "sample_names must contain at least one sample",
+        ));
+    }
+    if n_components == 0 {
+        return Err(PyValueError::new_err(
+            "n_components must be greater than or equal to 1",
+        ));
+    }
+
+    let variants: Vec<Variant> = variants.into_iter().map(VariantInput::into_inner).collect();
+    let result = compute_chromosome_pca(&variants, &sample_names, n_components)
+        .map_err(vcf_error_to_pyerr)?;
+    ChromosomePcaResult::from_result(py, &result)
+}
+
+/// Compute principal components for a chromosome and write them to a TSV file.
+#[pyfunction(
+    name = "chromosome_pca_to_file",
+    signature = (variants, sample_names, chromosome, output_dir, n_components=10),
+    text_signature = "(variants, sample_names, chromosome, output_dir, n_components=10, /)"
+)]
+fn chromosome_pca_to_file_py(
+    variants: Vec<VariantInput>,
+    sample_names: Vec<String>,
+    chromosome: &str,
+    output_dir: &str,
+    n_components: usize,
+) -> PyResult<()> {
+    if sample_names.is_empty() {
+        return Err(PyValueError::new_err(
+            "sample_names must contain at least one sample",
+        ));
+    }
+    if n_components == 0 {
+        return Err(PyValueError::new_err(
+            "n_components must be greater than or equal to 1",
+        ));
+    }
+
+    let variants: Vec<Variant> = variants.into_iter().map(VariantInput::into_inner).collect();
+    let result = compute_chromosome_pca(&variants, &sample_names, n_components)
+        .map_err(vcf_error_to_pyerr)?;
+    let output_dir = PathBuf::from(output_dir);
+    write_chromosome_pca_to_file(&result, chromosome, output_dir.as_path())
+        .map_err(vcf_error_to_pyerr)
+}
+
+/// Run per-chromosome PCA for a dictionary of chromosomes -> variants.
+#[pyfunction(
+    name = "per_chromosome_pca",
+    signature = (variants_by_chromosome, sample_names, output_dir, n_components=10),
+    text_signature = "(variants_by_chromosome, sample_names, output_dir, n_components=10, /)"
+)]
+fn per_chromosome_pca_py(
+    variants_by_chromosome: &PyAny,
+    sample_names: Vec<String>,
+    output_dir: &str,
+    n_components: usize,
+) -> PyResult<()> {
+    if sample_names.is_empty() {
+        return Err(PyValueError::new_err(
+            "sample_names must contain at least one sample",
+        ));
+    }
+    if n_components == 0 {
+        return Err(PyValueError::new_err(
+            "n_components must be greater than or equal to 1",
+        ));
+    }
+
+    let variants = extract_variants_by_chromosome(variants_by_chromosome)?;
+    let output_dir = PathBuf::from(output_dir);
+    run_chromosome_pca_analysis(&variants, &sample_names, output_dir.as_path(), n_components)
+        .map_err(vcf_error_to_pyerr)
+}
+
+/// Execute the memory-efficient multi-chromosome PCA pipeline.
+#[pyfunction(
+    name = "global_pca",
+    signature = (variants_by_chromosome, sample_names, output_dir, n_components=10),
+    text_signature = "(variants_by_chromosome, sample_names, output_dir, n_components=10, /)"
+)]
+fn global_pca_py(
+    variants_by_chromosome: &PyAny,
+    sample_names: Vec<String>,
+    output_dir: &str,
+    n_components: usize,
+) -> PyResult<()> {
+    if sample_names.is_empty() {
+        return Err(PyValueError::new_err(
+            "sample_names must contain at least one sample",
+        ));
+    }
+    if n_components == 0 {
+        return Err(PyValueError::new_err(
+            "n_components must be greater than or equal to 1",
+        ));
+    }
+
+    let variants = extract_variants_by_chromosome(variants_by_chromosome)?;
+    let output_dir = PathBuf::from(output_dir);
+    run_global_pca_analysis(&variants, &sample_names, output_dir.as_path(), n_components)
+        .map_err(vcf_error_to_pyerr)
+}
+
 /// Adjust the effective sequence length by applying allow and mask intervals.
 #[pyfunction(
     name = "adjusted_sequence_length",
@@ -1309,6 +1496,7 @@ fn inversion_allele_frequency_py(sample_map: &PyAny) -> PyResult<Option<f64>> {
 fn ferromic(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Population>()?;
     m.add_class::<PairwiseDifference>()?;
+    m.add_class::<ChromosomePcaResult>()?;
     m.add_class::<DiversitySite>()?;
     m.add_class::<HudsonDxyResultPy>()?;
     m.add_class::<HudsonFstSitePy>()?;
@@ -1328,6 +1516,10 @@ fn ferromic(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(hudson_fst_with_sites_py, m)?)?;
     m.add_function(wrap_pyfunction!(wc_fst_py, m)?)?;
     m.add_function(wrap_pyfunction!(wc_fst_components_py, m)?)?;
+    m.add_function(wrap_pyfunction!(chromosome_pca_py, m)?)?;
+    m.add_function(wrap_pyfunction!(chromosome_pca_to_file_py, m)?)?;
+    m.add_function(wrap_pyfunction!(per_chromosome_pca_py, m)?)?;
+    m.add_function(wrap_pyfunction!(global_pca_py, m)?)?;
     m.add_function(wrap_pyfunction!(adjusted_sequence_length_py, m)?)?;
     m.add_function(wrap_pyfunction!(inversion_allele_frequency_py, m)?)?;
 


### PR DESCRIPTION
## Summary
- add a `ChromosomePcaResult` Python class and expose helpers to compute PCA coordinates or write TSV outputs
- allow batch and memory-efficient PCA workflows from Python by bridging to the existing Rust routines
- document the new Python API entries and extend the end-to-end example with PCA usage

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cb5cf60950832e9cf2e63471b26644