### PR TITLE
Fix Population haplotype getter borrowing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,8 +539,8 @@ impl Population {
     /// When the identifier is a haplotype group, this returns its numeric value.
     #[getter]
     fn haplotype_group(&self) -> Option<u8> {
-        match self.inner.id {
-            PopulationId::HaplotypeGroup(group) => Some(group),
+        match &self.inner.id {
+            PopulationId::HaplotypeGroup(group) => Some(*group),
             PopulationId::Named(_) => None,
         }
     }


### PR DESCRIPTION
## Summary
- fix the `Population::haplotype_group` getter to borrow the population id rather than moving it

## Testing
- cargo test
- cargo clippy --all-targets
- .venv/bin/maturin develop
- .venv/bin/python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68cb6f871cf4832e96cf7644185393a7