### PR TITLE
Enable Stage-1 context flags and document removal of main

### DIFF
--- a/phewas/pipes.py
+++ b/phewas/pipes.py
@@ -11,7 +11,8 @@ from . import models
 from . import iox as io
 import time
 import random
-import queue
+
+# PHEWAS main removed: Stage-1 (LRT/Bootstrap) is the only engine.
 
 
 def cgroup_available_gb():

--- a/phewas/run.py
+++ b/phewas/run.py
@@ -725,6 +725,9 @@ def _pipeline_once():
                     "TARGET_INVERSION": target_inversion,
                     "CTX_TAG": ctx_tag_by_inversion.get(target_inversion),
                     "DATA_KEYS": data_keys,
+                    "STAGE1_REPORTS_FINAL": True,
+                    "STAGE1_MATCH_PHEWAS_DESIGN": True,
+                    "STAGE1_EMIT_PHEWAS_EXTRAS": True,
                 }
                 pheno.configure_from_ctx(ctx)
                 inversion_df = io.get_cached_or_generate(
@@ -1082,6 +1085,9 @@ def _pipeline_once():
                     "SELECTION": tctx.get("SELECTION"),
                     "TARGET_INVERSION": target_inversion,
                     "CTX_TAG": ctx_tag_by_inversion.get(target_inversion),
+                    "STAGE1_REPORTS_FINAL": True,
+                    "STAGE1_MATCH_PHEWAS_DESIGN": True,
+                    "STAGE1_EMIT_PHEWAS_EXTRAS": True,
                 }
 
                 pheno.configure_from_ctx(ctx)


### PR DESCRIPTION
## Summary
- ensure every Stage-1 invocation receives the flags that make it emit PheWAS-shaped results
- drop the unused queue import and note that PheWAS main has been removed in the pipes module

## Testing
- pytest phewas/tests.py *(fails: statsmodels not installed in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cc17813ffc832ebc07e7854332465d