### PR TITLE
Run cargo test --release in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose --release
+      - name: Test
+        run: cargo test --verbose --release
 
   create_release:
     name: Create Release


### PR DESCRIPTION
## Summary
- add a dedicated step to run `cargo test --release` in the Rust CI workflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc319b405c832e817fb86190f2d8ec