### PR TITLE
Run cargo test --release in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install build dependencies
+        if: ${{ matrix.platform.target == 'x86_64' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gfortran perl wget
+          perl -MIPC::Cmd -e1 >/dev/null 2>&1 || (wget -O - https://cpanmin.us | perl - --notest IPC::Cmd)
+      - name: Cargo tests
+        if: ${{ matrix.platform.target == 'x86_64' }}
+        env:
+          OPENBLAS_TARGET: ${{ matrix.platform.openblas_target }}
+        run: cargo test --release
       - name: Work around missing s390x assembler support
         if: ${{ matrix.platform.target == 's390x' }}
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose --release
+      - name: Test
+        run: cargo test --verbose --release
 
   create_release:
     name: Create Release


### PR DESCRIPTION
## Summary
- add a dedicated step to run `cargo test --release` in the Rust CI workflow
- run `cargo test --release` as part of the Linux job in `CI.yml`

## Testing
- cargo test --release

------
https://chatgpt.com/codex/tasks/task_e_68cc319b405c832e817fb86190f2d8ec