### PR TITLE
Add integration tests for Hudson FST against scikit-allel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+version = "0.1.0"
+name = "ferromic"
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "numpy",
+    "scikit-allel",
+]
+
+[tool.maturin]
+bindings = "pyo3"

--- a/src/pytests/test_ferromic.py
+++ b/src/pytests/test_ferromic.py
@@ -1,0 +1,64 @@
+import math
+
+import pytest
+
+import ferromic as fm
+
+
+def build_variant(position, genotypes):
+    """Helper to create a variant mapping for the Python API."""
+    return {"position": position, "genotypes": genotypes}
+
+
+def test_segregating_sites_counts_polymorphic_sites():
+    variants = [
+        build_variant(100, [[0, 0], [0, 1]]),
+        build_variant(150, [[0, 0], [0, 0]]),
+        build_variant(200, [[0, 1], [1, 1]]),
+    ]
+
+    assert fm.segregating_sites(variants) == 2
+
+
+def test_watterson_theta_matches_rust_implementation():
+    theta = fm.watterson_theta(3, 4, 100)
+    expected = 3 / (1 + 1 / 2 + 1 / 3) / 100
+
+    assert math.isclose(theta, expected, rel_tol=1e-12)
+
+
+def test_watterson_theta_requires_multiple_samples():
+    with pytest.raises(ValueError) as excinfo:
+        fm.watterson_theta(1, 1, 100)
+
+    assert "sample_count" in str(excinfo.value)
+
+
+def test_adjusted_sequence_length_respects_allow_and_mask_regions():
+    adjusted = fm.adjusted_sequence_length(
+        1,
+        100,
+        allow=[(11, 20), (40, 60)],
+        mask=[(45, 50)],
+    )
+
+    assert adjusted == 25
+
+
+def test_population_rejects_non_positive_sequence_length():
+    with pytest.raises(ValueError) as excinfo:
+        fm.Population("demo", [], [], 0)
+
+    assert "sequence_length" in str(excinfo.value)
+
+
+def test_inversion_allele_frequency_counts_haplotypes():
+    sample_map = {
+        "sampleA": (0, 1),
+        "sampleB": (1, 1),
+        "sampleC": (2, 255),  # ignored because they are not 0/1 alleles
+    }
+
+    frequency = fm.inversion_allele_frequency(sample_map)
+
+    assert frequency == pytest.approx(0.75)

--- a/src/pytests/test_hudson_fst_integration.py
+++ b/src/pytests/test_hudson_fst_integration.py
@@ -1,0 +1,127 @@
+import pytest
+
+import ferromic as fm
+
+allel = pytest.importorskip("allel")
+
+SAMPLE_NAMES = [
+    "pop1_individual_1",
+    "pop1_individual_2",
+    "pop2_individual_1",
+    "pop2_individual_2",
+]
+
+POP1_SAMPLES = [0, 1]
+POP2_SAMPLES = [2, 3]
+
+SEQUENCE_LENGTH = 3
+
+
+def make_variants():
+    """Return a small diploid genotype panel shared with scikit-allel."""
+    return [
+        {
+            "position": 0,
+            "genotypes": [
+                [0, 0],
+                [0, 0],
+                [1, 1],
+                [1, 1],
+            ],
+        },
+        {
+            "position": 1,
+            "genotypes": [
+                [0, 1],
+                [0, 0],
+                [0, 1],
+                [0, 1],
+            ],
+        },
+        {
+            "position": 2,
+            "genotypes": [
+                [0, 0],
+                [0, 1],
+                [0, 1],
+                [1, 1],
+            ],
+        },
+    ]
+
+
+def build_population(pop_id, sample_indices, variants):
+    haplotypes = [
+        (sample_index, haplotype_side)
+        for sample_index in sample_indices
+        for haplotype_side in (0, 1)
+    ]
+    return {
+        "id": pop_id,
+        "haplotypes": haplotypes,
+        "variants": variants,
+        "sequence_length": SEQUENCE_LENGTH,
+        "sample_names": SAMPLE_NAMES,
+    }
+
+
+@pytest.fixture()
+def hudson_dataset():
+    variants = make_variants()
+    genotype_array = allel.GenotypeArray([variant["genotypes"] for variant in variants])
+    subpops = [POP1_SAMPLES, POP2_SAMPLES]
+    allele_counts_1 = genotype_array.count_alleles(subpop=subpops[0])
+    allele_counts_2 = genotype_array.count_alleles(subpop=subpops[1])
+    numerator, denominator = allel.hudson_fst(allele_counts_1, allele_counts_2)
+
+    return {
+        "variants": variants,
+        "population1": build_population("pop1", POP1_SAMPLES, variants),
+        "population2": build_population("pop2", POP2_SAMPLES, variants),
+        "numerator": numerator,
+        "denominator": denominator,
+    }
+
+
+def test_hudson_fst_matches_scikit_allel_ratio_of_sums(hudson_dataset):
+    result = fm.hudson_fst(hudson_dataset["population1"], hudson_dataset["population2"])
+
+    numerator = hudson_dataset["numerator"]
+    denominator = hudson_dataset["denominator"]
+    expected_fst = float(numerator.sum() / denominator.sum())
+    expected_dxy = float(denominator.sum() / SEQUENCE_LENGTH)
+
+    assert result.fst == pytest.approx(expected_fst, rel=1e-12)
+    assert result.d_xy == pytest.approx(expected_dxy, rel=1e-12)
+
+
+def test_hudson_fst_site_components_align_with_scikit_allel(hudson_dataset):
+    region = (0, len(hudson_dataset["variants"]) - 1)
+    result, sites = fm.hudson_fst_with_sites(
+        hudson_dataset["population1"],
+        hudson_dataset["population2"],
+        region,
+    )
+
+    numerator = hudson_dataset["numerator"]
+    denominator = hudson_dataset["denominator"]
+    expected_fst = float(numerator.sum() / denominator.sum())
+    assert result.fst == pytest.approx(expected_fst, rel=1e-12)
+
+    informative_sites = [
+        site
+        for site in sites
+        if site.numerator_component is not None and site.denominator_component is not None
+    ]
+    assert len(informative_sites) == len(hudson_dataset["variants"])
+
+    for idx, site in enumerate(informative_sites):
+        position = hudson_dataset["variants"][idx]["position"] + 1
+        expected_num = float(numerator[idx])
+        expected_den = float(denominator[idx])
+        expected_site_fst = expected_num / expected_den
+
+        assert site.position == position
+        assert site.numerator_component == pytest.approx(expected_num, rel=1e-12)
+        assert site.denominator_component == pytest.approx(expected_den, rel=1e-12)
+        assert site.fst == pytest.approx(expected_site_fst, rel=1e-12)


### PR DESCRIPTION
## Summary
- add an optional `test` dependency group with numpy, pytest, and scikit-allel to support the integration suite
- add Hudson FST integration tests that cross-check ferromic's aggregated and per-site outputs against scikit-allel

## Testing
- `maturin develop`
- `.venv/bin/python -m pytest src/pytests -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc37bebe64832e965d1d4ada1219f0