### PR TITLE
Optimize pi computation throughput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(portable_simd)]
 //! Ergonomic Python bindings for Ferromic's population genetics toolkit.
 //!
 //! The bindings expose a high-level, well-documented API that mirrors the core


### PR DESCRIPTION
## Summary
- add reusable per-variant scratch state to compute π components without reallocations
- refactor aggregated and per-site π calculations to use the scratch metrics while preserving existing logging
- remove the nightly-only portable_simd feature gate so the crate builds on stable

## Testing
- cargo test --release

------
https://chatgpt.com/codex/tasks/task_e_68ccfaf7ea8c832e954a843da0fc4d6f