### PR TITLE
Show genomic region labels for inversion plots

### DIFF
--- a/stats/OR_matrix.py
+++ b/stats/OR_matrix.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle as MplRectangle
 from matplotlib.transforms import blended_transform_factory
 
+from _inv_common import map_inversion_series
+
 # =========================
 # Global configuration
 # =========================
@@ -262,6 +264,9 @@ def main():
 
     df = df.dropna(subset=["Inversion", "Phenotype", "OR"])
     df = df[df["OR"] > 0]
+
+    df["Inversion"] = df["Inversion"].astype(str)
+    df["Inversion"] = map_inversion_series(df["Inversion"])
 
     # Normed OR
     df["normed_OR"] = np.log(df["OR"].values)

--- a/stats/_inv_common.py
+++ b/stats/_inv_common.py
@@ -1,0 +1,96 @@
+"""Utility helpers for mapping inversion IDs to genomic region labels."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Dict
+
+import pandas as pd
+
+INV_INFO_PATH = "inv_info.tsv"
+
+
+def _to_int(value) -> int | None:
+    """Convert inv_info start/end values to integers (returns None on failure)."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    text = text.replace(",", "")
+    try:
+        return int(float(text))
+    except (TypeError, ValueError):
+        return None
+
+
+@lru_cache(maxsize=1)
+def load_inv_region_map(inv_info_path: str = INV_INFO_PATH) -> Dict[str, str]:
+    """Return a mapping {OrigID -> chr:start-end} using ``inv_info.tsv``."""
+    if not os.path.exists(inv_info_path):
+        return {}
+    try:
+        info_df = pd.read_csv(inv_info_path, sep="\t", dtype=str)
+    except Exception:
+        return {}
+
+    required = {"OrigID", "Chromosome", "Start", "End"}
+    if not required.issubset(info_df.columns):
+        return {}
+
+    mapping: Dict[str, str] = {}
+    for _, row in info_df.iterrows():
+        orig = (row.get("OrigID") or "").strip()
+        if not orig:
+            continue
+
+        chrom = (row.get("Chromosome") or "").strip()
+        if not chrom:
+            continue
+        chrom_fmt = chrom if chrom.lower().startswith("chr") else f"chr{chrom}"
+
+        start = _to_int(row.get("Start"))
+        end = _to_int(row.get("End"))
+        if start is None or end is None:
+            continue
+
+        mapping[orig] = f"{chrom_fmt}:{start:,}-{end:,}"
+    return mapping
+
+
+def map_inversion_value(value, inv_info_path: str = INV_INFO_PATH):
+    """Map a single inversion ID to its region label (falls back to the input)."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return value
+    key = str(value).strip()
+    if not key:
+        return value
+    mapping = load_inv_region_map(inv_info_path)
+    return mapping.get(key, value)
+
+
+def map_inversion_series(series: pd.Series, inv_info_path: str = INV_INFO_PATH) -> pd.Series:
+    """Vectorized helper that applies :func:`map_inversion_value` to a Series."""
+    mapping = load_inv_region_map(inv_info_path)
+    if not mapping:
+        return series
+
+    def convert(value):
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return value
+        text = str(value)
+        key = text.strip()
+        if not key:
+            return text
+        return mapping.get(key, key)
+
+    return series.apply(convert)
+
+
+__all__ = [
+    "INV_INFO_PATH",
+    "load_inv_region_map",
+    "map_inversion_value",
+    "map_inversion_series",
+]

--- a/stats/forest.py
+++ b/stats/forest.py
@@ -7,6 +7,8 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
+from _inv_common import map_inversion_series
+
 # --------------------------- Configuration ---------------------------
 
 INPUT_FILE       = "phewas_results.tsv"
@@ -151,6 +153,7 @@ def load_and_prepare(path: str) -> pd.DataFrame:
     # Types
     df["Phenotype"] = df["Phenotype"].fillna("").astype(str)
     df["Inversion"] = df["Inversion"].fillna("").astype(str)
+    df["Inversion"] = map_inversion_series(df["Inversion"])
     df["OR"]        = pd.to_numeric(df["OR"], errors="coerce")
     df["Q_GLOBAL"]  = pd.to_numeric(df["Q_GLOBAL"], errors="coerce")
 

--- a/stats/manhattan_phe.py
+++ b/stats/manhattan_phe.py
@@ -8,6 +8,8 @@ import matplotlib.colors as mcolors
 from matplotlib.patches import FancyArrowPatch
 from adjustText import adjust_text as ADJUST_TEXT  # required
 
+from _inv_common import map_inversion_series
+
 # ---------- Config ----------
 INFILE = "phewas_results.tsv"
 PHECODE_FILE = "phecodeX.csv"
@@ -519,9 +521,12 @@ def main():
         how="left", left_on="Phen_clean", right_on="clean_name"
     )
 
-    inv_mask = df[INV_COL].astype(str).str.strip() != ""
+    df[INV_COL] = df[INV_COL].fillna("").astype(str)
+    inv_mask = df[INV_COL].str.strip() != ""
     df = df[inv_mask].copy()
     if df.empty: sys.exit("No rows with a non-empty Inversion value.")
+
+    df[INV_COL] = map_inversion_series(df[INV_COL])
 
     made, to_open = [], []
     for inv, grp in df.groupby(INV_COL, dropna=False):

--- a/stats/volcano.py
+++ b/stats/volcano.py
@@ -9,6 +9,8 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import FancyArrowPatch
 from matplotlib import colors as mcolors
 
+from _inv_common import map_inversion_series
+
 INPUT_FILE = "phewas_results.tsv"
 OUTPUT_PDF = "phewas_volcano.pdf"
 
@@ -72,6 +74,7 @@ def load_and_prepare(path):
             raise SystemExit(f"ERROR: missing required column '{c}' in {path}")
 
     df["Inversion"] = df.get("Inversion", "Unknown").fillna("Unknown").astype(str)
+    df["Inversion"] = map_inversion_series(df["Inversion"])
     df["Phenotype"] = df.get("Phenotype", "").fillna("").astype(str)
 
     df["OR"] = pd.to_numeric(df["OR"], errors="coerce")


### PR DESCRIPTION
## Summary
- add a shared helper that converts inversion IDs to chr:start-end strings from `inv_info.tsv`
- update the volcano, forest, OR matrix, and Manhattan PheWAS plot scripts to use region labels in place of raw inversion IDs

## Testing
- python -m compileall stats/_inv_common.py stats/volcano.py stats/forest.py stats/OR_matrix.py stats/manhattan_phe.py

------
https://chatgpt.com/codex/tasks/task_e_68cd83fc5aac832e882ee04859699ec5