### PR TITLE
Fix PairDescriptor to include key for Python benchmarks

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -844,7 +844,7 @@ const INVALID_GROUP: u16 = u16::MAX;
 struct PairDescriptor {
     left: u16,
     right: u16,
-
+    key: String,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- add the missing `key` field to `PairDescriptor` so Python benchmarks can record comparison metadata correctly

## Testing
- `pytest src/pybenches/test_population_statistics_benchmarks.py --benchmark-json=bench.json`


------
https://chatgpt.com/codex/tasks/task_e_68cdb702ca54832ea0e899c2f075b56d