### PR TITLE
Accelerate dense statistics paths and beat scikit-allel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.18", features = ["extension-module"] }
+numpy = "0.18"
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.45", features = ["full"] }
 flate2 = "1.1" 

--- a/bench.json
+++ b/bench.json
@@ -1,0 +1,2511 @@
+{
+    "machine_info": {
+        "node": "e049ed350fb1",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC 13.3.0",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.12.10",
+        "python_version": "3.12.10",
+        "python_build": [
+            "main",
+            "Aug 28 2025 21:54:05"
+        ],
+        "release": "6.12.13",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.12.10.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 5,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "GenuineIntel",
+            "brand_raw": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
+            "hz_advertised_friendly": "2.8000 GHz",
+            "hz_actual_friendly": "2.7934 GHz",
+            "hz_advertised": [
+                2800000000,
+                0
+            ],
+            "hz_actual": [
+                2793436000,
+                0
+            ],
+            "stepping": 6,
+            "model": 106,
+            "family": 6,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arat",
+                "arch_capabilities",
+                "avx",
+                "avx2",
+                "avx512_bitalg",
+                "avx512_vbmi2",
+                "avx512_vnni",
+                "avx512_vpopcntdq",
+                "avx512bitalg",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512ifma",
+                "avx512vbmi",
+                "avx512vbmi2",
+                "avx512vl",
+                "avx512vnni",
+                "avx512vpopcntdq",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "clwb",
+                "cmov",
+                "constant_tsc",
+                "cpuid",
+                "cpuid_fault",
+                "cx16",
+                "cx8",
+                "de",
+                "erms",
+                "f16c",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fsrm",
+                "fxsr",
+                "gfni",
+                "hle",
+                "ht",
+                "hypervisor",
+                "invpcid",
+                "lahf_lm",
+                "lm",
+                "mca",
+                "mce",
+                "mmx",
+                "movbe",
+                "msr",
+                "mtrr",
+                "nonstop_tsc",
+                "nopl",
+                "nx",
+                "osxsave",
+                "pae",
+                "pat",
+                "pcid",
+                "pclmulqdq",
+                "pdpe1gb",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdpid",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "rtm",
+                "sep",
+                "sha",
+                "sha_ni",
+                "smap",
+                "smep",
+                "ss",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "syscall",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_known_freq",
+                "tscdeadline",
+                "umip",
+                "vaes",
+                "vme",
+                "vmx",
+                "vpclmulqdq",
+                "x2apic",
+                "xgetbv1",
+                "xsave",
+                "xsavec",
+                "xsaveopt",
+                "xsaves",
+                "xtopology"
+            ],
+            "l3_cache_size": 50331648,
+            "l2_cache_size": "3.8 MiB",
+            "l1_data_cache_size": 147456,
+            "l1_instruction_cache_size": 98304,
+            "l2_cache_line_size": 256,
+            "l2_cache_associativity": 6
+        }
+    },
+    "commit_info": {
+        "id": "cc798667818b8ddcff102bbb78d951990b5f7557",
+        "time": "2025-09-20T00:25:45+00:00",
+        "author_time": "2025-09-20T00:25:45+00:00",
+        "dirty": true,
+        "project": "ferromic",
+        "branch": "work"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_segregating_sites": 0.06448712083992739
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.0929998097708449e-06,
+                "max": 4.595000064000487e-06,
+                "mean": 1.9649999558168927e-06,
+                "stddev": 1.4903803988496543e-06,
+                "rounds": 5,
+                "median": 1.297999915550463e-06,
+                "iqr": 1.309750246036856e-06,
+                "q1": 1.1207498573639896e-06,
+                "q3": 2.4305001034008455e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.0929998097708449e-06,
+                "hd15iqr": 4.595000064000487e-06,
+                "ops": 508905.8638600724,
+                "total": 9.824999779084465e-06,
+                "data": [
+                    4.595000064000487e-06,
+                    1.7090001165342983e-06,
+                    1.297999915550463e-06,
+                    1.0929998097708449e-06,
+                    1.1299998732283711e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.6229999800998485e-05,
+                "max": 7.463799965989892e-05,
+                "mean": 3.0471199988824082e-05,
+                "stddev": 2.5061832142370967e-05,
+                "rounds": 5,
+                "median": 1.8297000224265503e-05,
+                "iqr": 2.2330749743559863e-05,
+                "q1": 1.6389750157941307e-05,
+                "q3": 3.872049990150117e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.6229999800998485e-05,
+                "hd15iqr": 7.463799965989892e-05,
+                "ops": 32817.87393889213,
+                "total": 0.0001523559999441204,
+                "data": [
+                    7.463799965989892e-05,
+                    2.6747999982035253e-05,
+                    1.8297000224265503e-05,
+                    1.6443000276922248e-05,
+                    1.6229999800998485e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_nucleotide_diversity": 0.022684430591744954
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.9109997992927674e-06,
+                "max": 4.165000063949265e-06,
+                "mean": 2.9795999580528585e-06,
+                "stddev": 8.521307736265487e-07,
+                "rounds": 5,
+                "median": 3.0559999686374795e-06,
+                "iqr": 1.175499733108154e-06,
+                "q1": 2.3340001007454703e-06,
+                "q3": 3.5094998338536243e-06,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.9109997992927674e-06,
+                "hd15iqr": 4.165000063949265e-06,
+                "ops": 335615.52358642494,
+                "total": 1.4897999790264294e-05,
+                "data": [
+                    4.165000063949265e-06,
+                    2.4750002012297045e-06,
+                    1.9109997992927674e-06,
+                    3.2909997571550775e-06,
+                    3.0559999686374795e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 8.987299997897935e-05,
+                "max": 0.00025393900023118476,
+                "mean": 0.00013134999999238063,
+                "stddev": 7.015175604954789e-05,
+                "rounds": 5,
+                "median": 9.528300006422796e-05,
+                "iqr": 6.745474979652499e-05,
+                "q1": 9.086975001082465e-05,
+                "q3": 0.00015832449980734964,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 8.987299997897935e-05,
+                "hd15iqr": 0.00025393900023118476,
+                "ops": 7613.2470503084,
+                "total": 0.0006567499999619031,
+                "data": [
+                    0.00025393900023118476,
+                    0.00012645299966607126,
+                    9.528300006422796e-05,
+                    9.120200002143974e-05,
+                    8.987299997897935e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic-pop1",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_population_1_nucleotide_diversity_population": 0.057345179172281074
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.296000265137991e-06,
+                "max": 8.272000286524417e-06,
+                "mean": 6.813800064264797e-06,
+                "stddev": 8.269657424709362e-07,
+                "rounds": 5,
+                "median": 6.504999873868655e-06,
+                "iqr": 7.219996405183338e-07,
+                "q1": 6.333500209620979e-06,
+                "q3": 7.055499850139313e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 6.296000265137991e-06,
+                "hd15iqr": 8.272000286524417e-06,
+                "ops": 146760.98367554598,
+                "total": 3.406900032132398e-05,
+                "data": [
+                    8.272000286524417e-06,
+                    6.649999704677612e-06,
+                    6.3460001911153086e-06,
+                    6.296000265137991e-06,
+                    6.504999873868655e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic-pop2",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_population_2_nucleotide_diversity_population": 0.017236507426725965
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.7330003174720332e-06,
+                "max": 3.470000137895113e-06,
+                "mean": 2.1473999368026854e-06,
+                "stddev": 7.426819219777247e-07,
+                "rounds": 5,
+                "median": 1.8349996935285162e-06,
+                "iqr": 5.41499844075588e-07,
+                "q1": 1.7667499605522607e-06,
+                "q3": 2.308249804627849e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.7330003174720332e-06,
+                "hd15iqr": 3.470000137895113e-06,
+                "ops": 465679.43998774805,
+                "total": 1.0736999684013426e-05,
+                "data": [
+                    3.470000137895113e-06,
+                    1.9209996935387608e-06,
+                    1.8349996935285162e-06,
+                    1.7779998415790033e-06,
+                    1.7330003174720332e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 9.36789997467713e-05,
+                "max": 0.00016689799986124854,
+                "mean": 0.00011882079998031259,
+                "stddev": 3.000046445453037e-05,
+                "rounds": 5,
+                "median": 0.00011459000006652786,
+                "iqr": 4.114599994409218e-05,
+                "q1": 9.41005000640871e-05,
+                "q3": 0.00013524650000817928,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 9.36789997467713e-05,
+                "hd15iqr": 0.00016689799986124854,
+                "ops": 8416.034904374403,
+                "total": 0.0005941039999015629,
+                "data": [
+                    0.00016689799986124854,
+                    0.0001246960000571562,
+                    0.00011459000006652786,
+                    9.36789997467713e-05,
+                    9.424100016985903e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 9.14360002752801e-05,
+                "max": 0.0001675809999142075,
+                "mean": 0.0001245844000550278,
+                "stddev": 3.086581551519642e-05,
+                "rounds": 5,
+                "median": 0.00011144100017190794,
+                "iqr": 4.679824996856041e-05,
+                "q1": 0.00010365200000705954,
+                "q3": 0.00015045024997561995,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 9.14360002752801e-05,
+                "hd15iqr": 0.0001675809999142075,
+                "ops": 8026.687125822407,
+                "total": 0.000622922000275139,
+                "data": [
+                    0.0001675809999142075,
+                    9.14360002752801e-05,
+                    0.00011144100017190794,
+                    0.00010772399991765269,
+                    0.00014473999999609077
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_watterson_theta": 0.01908991302094884
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 5.070000952400733e-07,
+                "max": 5.28800001120544e-06,
+                "mean": 1.6867999875103123e-06,
+                "stddev": 2.0545234523812567e-06,
+                "rounds": 5,
+                "median": 6.400000529538374e-07,
+                "iqr": 1.932499685608491e-06,
+                "q1": 5.077500873085228e-07,
+                "q3": 2.4402497729170136e-06,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 5.070000952400733e-07,
+                "hd15iqr": 5.28800001120544e-06,
+                "ops": 592838.5151792553,
+                "total": 8.433999937551562e-06,
+                "data": [
+                    5.28800001120544e-06,
+                    1.490999693487538e-06,
+                    6.400000529538374e-07,
+                    5.080000846646726e-07,
+                    5.070000952400733e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.085800007189391e-05,
+                "max": 0.00014753600044059567,
+                "mean": 8.836080005494295e-05,
+                "stddev": 3.323649359958904e-05,
+                "rounds": 5,
+                "median": 7.251199986058054e-05,
+                "iqr": 2.457699986280204e-05,
+                "q1": 7.159750009577692e-05,
+                "q3": 9.617449995857896e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.085800007189391e-05,
+                "hd15iqr": 0.00014753600044059567,
+                "ops": 11317.23569024044,
+                "total": 0.0004418040002747148,
+                "data": [
+                    0.00014753600044059567,
+                    7.905399979790673e-05,
+                    7.184400010373793e-05,
+                    7.251199986058054e-05,
+                    7.085800007189391e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "fst": 0.008230076904854772,
+                "d_xy": 0.012796184802120558,
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_hudson_fst": 0.06281457692254834
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.0320000001229346e-05,
+                "max": 1.8902000192611013e-05,
+                "mean": 1.2537400107248686e-05,
+                "stddev": 3.641614647708226e-06,
+                "rounds": 5,
+                "median": 1.0880999980145134e-05,
+                "iqr": 3.5585001114668557e-06,
+                "q1": 1.0342500104343344e-05,
+                "q3": 1.39010002158102e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 1.0320000001229346e-05,
+                "hd15iqr": 1.8902000192611013e-05,
+                "ops": 79761.35334644341,
+                "total": 6.268700053624343e-05,
+                "data": [
+                    1.8902000192611013e-05,
+                    1.2234000223543262e-05,
+                    1.0880999980145134e-05,
+                    1.0320000001229346e-05,
+                    1.0350000138714677e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel",
+                "fst": 0.008230076904854744,
+                "d_xy": 0.012796184802120558
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00015537600029347232,
+                "max": 0.0003205469997737964,
+                "mean": 0.00019959380006184801,
+                "stddev": 7.039020082057055e-05,
+                "rounds": 5,
+                "median": 0.00015971999982866691,
+                "iqr": 7.424024965985154e-05,
+                "q1": 0.00015824250033347198,
+                "q3": 0.00023248274999332352,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00015537600029347232,
+                "hd15iqr": 0.0003205469997737964,
+                "ops": 5010.175665226729,
+                "total": 0.00099796900030924,
+                "data": [
+                    0.0003205469997737964,
+                    0.00020312800006649923,
+                    0.0001591980003468052,
+                    0.00015971999982866691,
+                    0.00015537600029347232
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_segregating_sites": 0.036272708737457075
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.2790000002714805e-06,
+                "max": 7.989000096131349e-06,
+                "mean": 3.4626000342541374e-06,
+                "stddev": 2.5310761475221096e-06,
+                "rounds": 5,
+                "median": 2.3340003281191457e-06,
+                "iqr": 1.5392498653454822e-06,
+                "q1": 2.2804999844083795e-06,
+                "q3": 3.819749849753862e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.2790000002714805e-06,
+                "hd15iqr": 7.989000096131349e-06,
+                "ops": 288800.3205993745,
+                "total": 1.7313000171270687e-05,
+                "data": [
+                    7.989000096131349e-06,
+                    2.4299997676280327e-06,
+                    2.3340003281191457e-06,
+                    2.280999979120679e-06,
+                    2.2790000002714805e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.053400031509227e-05,
+                "max": 0.000188747000265721,
+                "mean": 9.546020010020584e-05,
+                "stddev": 5.2190434877809436e-05,
+                "rounds": 5,
+                "median": 7.15820001460088e-05,
+                "iqr": 3.324475017052464e-05,
+                "q1": 7.070199990266701e-05,
+                "q3": 0.00010394675007319165,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.053400031509227e-05,
+                "hd15iqr": 0.000188747000265721,
+                "ops": 10475.569912385337,
+                "total": 0.0004773010005010292,
+                "data": [
+                    0.000188747000265721,
+                    7.56800000090152e-05,
+                    7.15820001460088e-05,
+                    7.075799976519193e-05,
+                    7.053400031509227e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_nucleotide_diversity": 0.045171199790127854
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.2044999948557233e-05,
+                "max": 1.7221999769390095e-05,
+                "mean": 1.315079980486189e-05,
+                "stddev": 2.2789136848008243e-06,
+                "rounds": 5,
+                "median": 1.2097999842808349e-05,
+                "iqr": 1.5034997886687052e-06,
+                "q1": 1.2052499869241728e-05,
+                "q3": 1.3555999657910434e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.2044999948557233e-05,
+                "hd15iqr": 1.7221999769390095e-05,
+                "ops": 76041.00243623943,
+                "total": 6.575399902430945e-05,
+                "data": [
+                    1.7221999769390095e-05,
+                    1.2333999620750546e-05,
+                    1.2097999842808349e-05,
+                    1.2044999948557233e-05,
+                    1.2054999842803227e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00024100900009216275,
+                "max": 0.0003987059999417397,
+                "mean": 0.00029113239997968776,
+                "stddev": 6.432130681915343e-05,
+                "rounds": 5,
+                "median": 0.00025956999979825923,
+                "iqr": 7.512949991905771e-05,
+                "q1": 0.00025104100006956287,
+                "q3": 0.0003261704999886206,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00024100900009216275,
+                "hd15iqr": 0.0003987059999417397,
+                "ops": 3434.86331328897,
+                "total": 0.0014556619998984388,
+                "data": [
+                    0.0003987059999417397,
+                    0.00030199200000424753,
+                    0.00025956999979825923,
+                    0.0002543850000620296,
+                    0.00024100900009216275
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic-pop1",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_population_1_nucleotide_diversity_population": 0.16345660489978142
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 3.3799999982875306e-05,
+                "max": 5.0362999900244176e-05,
+                "mean": 4.3203999848628885e-05,
+                "stddev": 7.514195278321308e-06,
+                "rounds": 5,
+                "median": 4.742900000564987e-05,
+                "iqr": 1.2780750012097997e-05,
+                "q1": 3.5790499737231585e-05,
+                "q3": 4.857124974932958e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 3.3799999982875306e-05,
+                "hd15iqr": 5.0362999900244176e-05,
+                "ops": 23146.005080632272,
+                "total": 0.0002160199992431444,
+                "data": [
+                    5.0362999900244176e-05,
+                    4.7973999699024716e-05,
+                    4.742900000564987e-05,
+                    3.3799999982875306e-05,
+                    3.6453999655350344e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic-pop2",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_population_2_nucleotide_diversity_population": 0.04948773217792422
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.1891000212926883e-05,
+                "max": 1.5829999938432593e-05,
+                "mean": 1.2777000029018381e-05,
+                "stddev": 1.7123800158826883e-06,
+                "rounds": 5,
+                "median": 1.1974999779340578e-05,
+                "iqr": 1.2179998520878144e-06,
+                "q1": 1.1927000173272972e-05,
+                "q3": 1.3145000025360787e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.1891000212926883e-05,
+                "hd15iqr": 1.5829999938432593e-05,
+                "ops": 78265.6333825513,
+                "total": 6.388500014509191e-05,
+                "data": [
+                    1.5829999938432593e-05,
+                    1.2250000054336851e-05,
+                    1.1974999779340578e-05,
+                    1.1939000160055002e-05,
+                    1.1891000212926883e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00023865799994382542,
+                "max": 0.00033985800018854206,
+                "mean": 0.0002643148000970541,
+                "stddev": 4.2730123687274154e-05,
+                "rounds": 5,
+                "median": 0.00025164599992422154,
+                "iqr": 3.509799978473893e-05,
+                "q1": 0.00023904500028493203,
+                "q3": 0.00027414300006967096,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00023865799994382542,
+                "hd15iqr": 0.00033985800018854206,
+                "ops": 3783.3674074732426,
+                "total": 0.0013215740004852705,
+                "data": [
+                    0.00033985800018854206,
+                    0.00025223800003004726,
+                    0.00023917400039863423,
+                    0.00023865799994382542,
+                    0.00025164599992422154
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0002379079996899236,
+                "max": 0.00031435400023838156,
+                "mean": 0.0002581851999821083,
+                "stddev": 3.2011147719455594e-05,
+                "rounds": 5,
+                "median": 0.0002452329999869107,
+                "iqr": 2.9817750487382e-05,
+                "q1": 0.00023916049974559428,
+                "q3": 0.0002689782502329763,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0002379079996899236,
+                "hd15iqr": 0.00031435400023838156,
+                "ops": 3873.188703571304,
+                "total": 0.0012909259999105416,
+                "data": [
+                    0.00031435400023838156,
+                    0.00023957799976415117,
+                    0.0002379079996899236,
+                    0.0002538530002311745,
+                    0.0002452329999869107
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_watterson_theta": 0.006283311136970262
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 5.320002856024075e-07,
+                "max": 4.236000222590519e-06,
+                "mean": 1.3402001059148461e-06,
+                "stddev": 1.6225049810113614e-06,
+                "rounds": 5,
+                "median": 5.769998097093776e-07,
+                "iqr": 1.1150000318593811e-06,
+                "q1": 5.470001269713975e-07,
+                "q3": 1.6620001588307787e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 5.320002856024075e-07,
+                "hd15iqr": 4.236000222590519e-06,
+                "ops": 746157.2309885627,
+                "total": 6.70100052957423e-06,
+                "data": [
+                    4.236000222590519e-06,
+                    8.040001375775319e-07,
+                    5.769998097093776e-07,
+                    5.520000740943942e-07,
+                    5.320002856024075e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00018675399996936903,
+                "max": 0.00027017299998988165,
+                "mean": 0.00021329520004655932,
+                "stddev": 3.444881045292977e-05,
+                "rounds": 5,
+                "median": 0.00019967600019299425,
+                "iqr": 4.414449995238101e-05,
+                "q1": 0.00018874600004892272,
+                "q3": 0.00023289050000130374,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00018675399996936903,
+                "hd15iqr": 0.00027017299998988165,
+                "ops": 4688.338039401328,
+                "total": 0.0010664760002327967,
+                "data": [
+                    0.00027017299998988165,
+                    0.00019967600019299425,
+                    0.00018941000007544062,
+                    0.00018675399996936903,
+                    0.0002204630000051111
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "fst": 0.028746943727020576,
+                "d_xy": 0.012981536777004749,
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_hudson_fst": 0.14884249476047176
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.7003000114928e-05,
+                "max": 9.247999969375087e-05,
+                "mean": 8.133900000757421e-05,
+                "stddev": 6.34380408264569e-06,
+                "rounds": 5,
+                "median": 7.934699988254579e-05,
+                "iqr": 5.546999886973936e-06,
+                "q1": 7.76112501625903e-05,
+                "q3": 8.315825004956423e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.7003000114928e-05,
+                "hd15iqr": 9.247999969375087e-05,
+                "ops": 12294.2254011837,
+                "total": 0.00040669500003787107,
+                "data": [
+                    9.247999969375087e-05,
+                    8.005100016816868e-05,
+                    7.934699988254579e-05,
+                    7.781400017847773e-05,
+                    7.7003000114928e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel",
+                "fst": 0.028746943727020562,
+                "d_xy": 0.012981536777004777
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0005182009999771253,
+                "max": 0.0006015669996486395,
+                "mean": 0.000546476999988954,
+                "stddev": 3.3785488357716695e-05,
+                "rounds": 5,
+                "median": 0.000530538000020897,
+                "iqr": 4.253225006323191e-05,
+                "q1": 0.0005244845000333953,
+                "q3": 0.0005670167500966272,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0005182009999771253,
+                "hd15iqr": 0.0006015669996486395,
+                "ops": 1829.9031798597434,
+                "total": 0.0027323849999447702,
+                "data": [
+                    0.0006015669996486395,
+                    0.0005182009999771253,
+                    0.000530538000020897,
+                    0.0005555000002459565,
+                    0.000526579000052152
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_segregating_sites": 0.035587421590274664
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 8.024000180739677e-06,
+                "max": 2.2997000087343622e-05,
+                "mean": 1.1844250138892676e-05,
+                "stddev": 7.435624323547747e-06,
+                "rounds": 4,
+                "median": 8.178000143743702e-06,
+                "iqr": 7.534500127803767e-06,
+                "q1": 8.077000074990792e-06,
+                "q3": 1.561150020279456e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 8.024000180739677e-06,
+                "hd15iqr": 2.2997000087343622e-05,
+                "ops": 84429.15239659828,
+                "total": 4.73770005555707e-05,
+                "data": [
+                    2.2997000087343622e-05,
+                    8.226000318245497e-06,
+                    8.129999969241908e-06,
+                    8.024000180739677e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00025839499994617654,
+                "max": 0.0005052760002399737,
+                "mean": 0.00033282125002642715,
+                "stddev": 0.00011589587948294506,
+                "rounds": 4,
+                "median": 0.0002838069999597792,
+                "iqr": 0.0001337085002433014,
+                "q1": 0.00026596699990477646,
+                "q3": 0.00039967550014807784,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00025839499994617654,
+                "hd15iqr": 0.0005052760002399737,
+                "ops": 3004.6158408472916,
+                "total": 0.0013312850001057086,
+                "data": [
+                    0.0005052760002399737,
+                    0.00029407500005618203,
+                    0.0002735389998633764,
+                    0.00025839499994617654
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_nucleotide_diversity": 0.05561743057924603
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.863300000579329e-05,
+                "max": 5.547799992200453e-05,
+                "mean": 5.04240000509526e-05,
+                "stddev": 3.3705584281329583e-06,
+                "rounds": 4,
+                "median": 4.879250013800629e-05,
+                "iqr": 3.4850002066377783e-06,
+                "q1": 4.868149994763371e-05,
+                "q3": 5.216650015427149e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 4.863300000579329e-05,
+                "hd15iqr": 5.547799992200453e-05,
+                "ops": 19831.826094508902,
+                "total": 0.0002016960002038104,
+                "data": [
+                    5.547799992200453e-05,
+                    4.885500038653845e-05,
+                    4.872999988947413e-05,
+                    4.863300000579329e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0008148980000441952,
+                "max": 0.0011023100000784325,
+                "mean": 0.0009066222499996002,
+                "stddev": 0.000133074747607024,
+                "rounds": 4,
+                "median": 0.0008546404999378865,
+                "iqr": 0.000166238500014515,
+                "q1": 0.0008235029999923427,
+                "q3": 0.0009897415000068577,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0008148980000441952,
+                "hd15iqr": 0.0011023100000784325,
+                "ops": 1102.9952110710287,
+                "total": 0.0036264889999984007,
+                "data": [
+                    0.0011023100000784325,
+                    0.0008771729999352829,
+                    0.0008148980000441952,
+                    0.0008321079999404901
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic-pop1",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_population_1_nucleotide_diversity_population": 0.07181769381804509
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.8938999952952145e-05,
+                "max": 9.548700018058298e-05,
+                "mean": 6.365125000229455e-05,
+                "stddev": 2.1988949489990697e-05,
+                "rounds": 4,
+                "median": 5.508949993782153e-05,
+                "iqr": 2.9355499918892747e-05,
+                "q1": 4.897350004284817e-05,
+                "q3": 7.832899996174092e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 4.8938999952952145e-05,
+                "hd15iqr": 9.548700018058298e-05,
+                "ops": 15710.610553036293,
+                "total": 0.0002546050000091782,
+                "data": [
+                    6.117099974289886e-05,
+                    4.90080001327442e-05,
+                    4.8938999952952145e-05,
+                    9.548700018058298e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic-pop2",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_population_2_nucleotide_diversity_population": 0.05950660475825014
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.8194000100920675e-05,
+                "max": 6.317499992292142e-05,
+                "mean": 5.347625005924783e-05,
+                "stddev": 7.0741539171560535e-06,
+                "rounds": 4,
+                "median": 5.126800010657462e-05,
+                "iqr": 1.0524499884922989e-05,
+                "q1": 4.821400011678634e-05,
+                "q3": 5.8738500001709326e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 4.8194000100920675e-05,
+                "hd15iqr": 6.317499992292142e-05,
+                "ops": 18699.89011742731,
+                "total": 0.00021390500023699133,
+                "data": [
+                    5.430200008049724e-05,
+                    4.8234000132652e-05,
+                    6.317499992292142e-05,
+                    4.8194000100920675e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0008187339999494725,
+                "max": 0.0009420800001862517,
+                "mean": 0.0008862892501610986,
+                "stddev": 5.660228005370017e-05,
+                "rounds": 4,
+                "median": 0.0008921715002543351,
+                "iqr": 9.221750019605679e-05,
+                "q1": 0.0008401805000630702,
+                "q3": 0.000932398000259127,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0008187339999494725,
+                "hd15iqr": 0.0009420800001862517,
+                "ops": 1128.2998183925083,
+                "total": 0.0035451570006443944,
+                "data": [
+                    0.0009420800001862517,
+                    0.0008616270001766679,
+                    0.0009227160003320023,
+                    0.0008187339999494725
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0008555159997740702,
+                "max": 0.0009400170001754304,
+                "mean": 0.0008986607499537058,
+                "stddev": 3.946541430233328e-05,
+                "rounds": 4,
+                "median": 0.0008995549999326613,
+                "iqr": 6.569350034624222e-05,
+                "q1": 0.0008658139997805847,
+                "q3": 0.0009315075001268269,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0008555159997740702,
+                "hd15iqr": 0.0009400170001754304,
+                "ops": 1112.7669702404546,
+                "total": 0.0035946429998148233,
+                "data": [
+                    0.0009229980000782234,
+                    0.0009400170001754304,
+                    0.0008761119997870992,
+                    0.0008555159997740702
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_watterson_theta": 0.00897050341391282
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 8.040001375775319e-07,
+                "max": 2.0460000087041408e-05,
+                "mean": 5.853000061506464e-06,
+                "stddev": 9.739774894577193e-06,
+                "rounds": 4,
+                "median": 1.0740000107034575e-06,
+                "iqr": 9.994000038204831e-06,
+                "q1": 8.560000424040481e-07,
+                "q3": 1.085000008060888e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 8.040001375775319e-07,
+                "hd15iqr": 2.0460000087041408e-05,
+                "ops": 170852.5524502757,
+                "total": 2.3412000246025855e-05,
+                "data": [
+                    2.0460000087041408e-05,
+                    1.2400000741763506e-06,
+                    9.079999472305644e-07,
+                    8.040001375775319e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0006195820001266839,
+                "max": 0.0007189499997366511,
+                "mean": 0.0006524717500724364,
+                "stddev": 4.591375445249544e-05,
+                "rounds": 4,
+                "median": 0.0006356775002132053,
+                "iqr": 6.106449973231065e-05,
+                "q1": 0.0006219395002062811,
+                "q3": 0.0006830039999385917,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0006195820001266839,
+                "hd15iqr": 0.0007189499997366511,
+                "ops": 1532.6334050309174,
+                "total": 0.0026098870002897456,
+                "data": [
+                    0.0007189499997366511,
+                    0.0006470580001405324,
+                    0.0006195820001266839,
+                    0.0006242970002858783
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "fst": 0.06676412120482449,
+                "d_xy": 0.013018435627179586,
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_hudson_fst": 0.16681242234690172
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00030767099997319747,
+                "max": 0.00037479499997061794,
+                "mean": 0.0003387142500059781,
+                "stddev": 2.8521069027724068e-05,
+                "rounds": 4,
+                "median": 0.0003361955000400485,
+                "iqr": 4.2566500042084954e-05,
+                "q1": 0.0003174309999849356,
+                "q3": 0.0003599975000270206,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.00030767099997319747,
+                "hd15iqr": 0.00037479499997061794,
+                "ops": 2952.3410957240526,
+                "total": 0.0013548570000239124,
+                "data": [
+                    0.00037479499997061794,
+                    0.00030767099997319747,
+                    0.0003452000000834232,
+                    0.0003271909999966738
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel",
+                "fst": 0.06676412120482433,
+                "d_xy": 0.013018435627179586
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0018638740002643317,
+                "max": 0.0022084239999458077,
+                "mean": 0.002030509750056808,
+                "stddev": 0.00014216186676628868,
+                "rounds": 4,
+                "median": 0.0020248705000085465,
+                "iqr": 0.00019620649982243776,
+                "q1": 0.0019324065001455892,
+                "q3": 0.002128612999968027,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0018638740002643317,
+                "hd15iqr": 0.0022084239999458077,
+                "ops": 492.4871697720352,
+                "total": 0.008122039000227232,
+                "data": [
+                    0.0022084239999458077,
+                    0.0020009390000268468,
+                    0.0020488019999902463,
+                    0.0018638740002643317
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_segregating_sites": 0.03902207082157005
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 3.060200015170267e-05,
+                "max": 7.959399999890593e-05,
+                "mean": 4.748800013961348e-05,
+                "stddev": 2.7817086643297746e-05,
+                "rounds": 3,
+                "median": 3.2268000268231845e-05,
+                "iqr": 3.6743999885402445e-05,
+                "q1": 3.101850018083496e-05,
+                "q3": 6.776250006623741e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 3.060200015170267e-05,
+                "hd15iqr": 7.959399999890593e-05,
+                "ops": 21057.951420569956,
+                "total": 0.00014246400041884044,
+                "data": [
+                    7.959399999890593e-05,
+                    3.2268000268231845e-05,
+                    3.060200015170267e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0011475760002213065,
+                "max": 0.001313353000114148,
+                "mean": 0.001216952333379595,
+                "stddev": 8.612920165250984e-05,
+                "rounds": 3,
+                "median": 0.0011899279998033307,
+                "iqr": 0.00012433274991963117,
+                "q1": 0.0011581640001168125,
+                "q3": 0.0012824967500364437,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0011475760002213065,
+                "hd15iqr": 0.001313353000114148,
+                "ops": 821.7248716906624,
+                "total": 0.0036508570001387852,
+                "data": [
+                    0.001313353000114148,
+                    0.0011475760002213065,
+                    0.0011899279998033307
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_nucleotide_diversity": 0.0582373003878617
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00018656900010682875,
+                "max": 0.0001986550000765419,
+                "mean": 0.00019085200013554035,
+                "stddev": 6.76835639973751e-06,
+                "rounds": 3,
+                "median": 0.00018733200022325036,
+                "iqr": 9.064499977284868e-06,
+                "q1": 0.00018675975013593415,
+                "q3": 0.00019582425011321902,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00018656900010682875,
+                "hd15iqr": 0.0001986550000765419,
+                "ops": 5239.662142863655,
+                "total": 0.000572556000406621,
+                "data": [
+                    0.0001986550000765419,
+                    0.00018733200022325036,
+                    0.00018656900010682875
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0030507730002682365,
+                "max": 0.003633155999978044,
+                "mean": 0.0032771436667644593,
+                "stddev": 0.0003120860632897438,
+                "rounds": 3,
+                "median": 0.0031475020000470977,
+                "iqr": 0.0004367872497823555,
+                "q1": 0.003074955250212952,
+                "q3": 0.0035117424999953073,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0030507730002682365,
+                "hd15iqr": 0.003633155999978044,
+                "ops": 305.14377814485783,
+                "total": 0.009831431000293378,
+                "data": [
+                    0.003633155999978044,
+                    0.0031475020000470977,
+                    0.0030507730002682365
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic-pop1",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_population_1_nucleotide_diversity_population": 0.060451897295958706
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00018573500028651324,
+                "max": 0.00020025999992867582,
+                "mean": 0.0001909430000826736,
+                "stddev": 8.087447972531653e-06,
+                "rounds": 3,
+                "median": 0.00018683400003283168,
+                "iqr": 1.0893749731621938e-05,
+                "q1": 0.00018600975022309285,
+                "q3": 0.0001969034999547148,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00018573500028651324,
+                "hd15iqr": 0.00020025999992867582,
+                "ops": 5237.165015564984,
+                "total": 0.0005728290002480207,
+                "data": [
+                    0.00020025999992867582,
+                    0.00018683400003283168,
+                    0.00018573500028651324
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic-pop2",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_population_2_nucleotide_diversity_population": 0.06702103715467134
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00018556300028649275,
+                "max": 0.00023037300024952856,
+                "mean": 0.00020899800013770195,
+                "stddev": 2.247591429433983e-05,
+                "rounds": 3,
+                "median": 0.0002110579998770845,
+                "iqr": 3.3607499972276855e-05,
+                "q1": 0.0001919367501841407,
+                "q3": 0.00022554425015641755,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00018556300028649275,
+                "hd15iqr": 0.00023037300024952856,
+                "ops": 4784.734778998521,
+                "total": 0.0006269940004131058,
+                "data": [
+                    0.00023037300024952856,
+                    0.0002110579998770845,
+                    0.00018556300028649275
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003070055000080174,
+                "max": 0.0032414610000159882,
+                "mean": 0.0031585939999179877,
+                "stddev": 8.584365375078935e-05,
+                "rounds": 3,
+                "median": 0.0031642659996578004,
+                "iqr": 0.00012855449995186063,
+                "q1": 0.0030936077499745807,
+                "q3": 0.0032221622499264413,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.003070055000080174,
+                "hd15iqr": 0.0032414610000159882,
+                "ops": 316.5965616429224,
+                "total": 0.009475781999753963,
+                "data": [
+                    0.0031642659996578004,
+                    0.003070055000080174,
+                    0.0032414610000159882
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003071058999921661,
+                "max": 0.003162086999964231,
+                "mean": 0.0031183940000119037,
+                "stddev": 4.5623155542892544e-05,
+                "rounds": 3,
+                "median": 0.0031220360001498193,
+                "iqr": 6.827100003192754e-05,
+                "q1": 0.0030838032499787005,
+                "q3": 0.003152074250010628,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.003071058999921661,
+                "hd15iqr": 0.003162086999964231,
+                "ops": 320.67788739850795,
+                "total": 0.009355182000035711,
+                "data": [
+                    0.0031220360001498193,
+                    0.003071058999921661,
+                    0.003162086999964231
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_watterson_theta": 0.0013741482517206167
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.159998520161025e-07,
+                "max": 9.089999821298989e-06,
+                "mean": 3.5166666142079825e-06,
+                "stddev": 4.82799423302461e-06,
+                "rounds": 3,
+                "median": 8.440001693088561e-07,
+                "iqr": 6.3554999769621645e-06,
+                "q1": 6.729999313392909e-07,
+                "q3": 7.0284999083014554e-06,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 6.159998520161025e-07,
+                "hd15iqr": 9.089999821298989e-06,
+                "ops": 284360.19381530664,
+                "total": 1.0549999842623947e-05,
+                "data": [
+                    9.089999821298989e-06,
+                    8.440001693088561e-07,
+                    6.159998520161025e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00244538900005864,
+                "max": 0.0027695420003510662,
+                "mean": 0.0025591610001356457,
+                "stddev": 0.00018239727541949084,
+                "rounds": 3,
+                "median": 0.002462551999997231,
+                "iqr": 0.00024311475021931983,
+                "q1": 0.0024496797500432876,
+                "q3": 0.0026927945002626075,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00244538900005864,
+                "hd15iqr": 0.0027695420003510662,
+                "ops": 390.7530631902393,
+                "total": 0.007677483000406937,
+                "data": [
+                    0.002462551999997231,
+                    0.00244538900005864,
+                    0.0027695420003510662
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "fst": 0.09871859560569146,
+                "d_xy": 0.01341475163945433,
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_hudson_fst": 0.18700677867570126
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0013109029996485333,
+                "max": 0.001588646000072913,
+                "mean": 0.0014089753332579373,
+                "stddev": 0.00015581723126031308,
+                "rounds": 3,
+                "median": 0.0013273770000523655,
+                "iqr": 0.0002083072503182848,
+                "q1": 0.0013150214997494913,
+                "q3": 0.0015233287500677761,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0013109029996485333,
+                "hd15iqr": 0.001588646000072913,
+                "ops": 709.7356329778505,
+                "total": 0.004226925999773812,
+                "data": [
+                    0.001588646000072913,
+                    0.0013273770000523655,
+                    0.0013109029996485333
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel",
+                "fst": 0.0987185956056903,
+                "d_xy": 0.01341475163945433
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.007235605000005307,
+                "max": 0.00801127099975929,
+                "mean": 0.0075343543332261715,
+                "stddev": 0.0004173992510633992,
+                "rounds": 3,
+                "median": 0.007356186999913916,
+                "iqr": 0.0005817494998154871,
+                "q1": 0.00726575049998246,
+                "q3": 0.007847499999797947,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.007235605000005307,
+                "hd15iqr": 0.00801127099975929,
+                "ops": 132.72537443454763,
+                "total": 0.022603062999678514,
+                "data": [
+                    0.00801127099975929,
+                    0.007356186999913916,
+                    0.007235605000005307
+                ],
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2025-09-20T01:11:53.949413+00:00",
+    "version": "5.1.0"
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,9 +1,9 @@
 use crate::process::{ConfigEntry, VcfError, ZeroBasedHalfOpen};
-use crate::transcripts::TranscriptAnnotationCDS;
 use crate::progress::{
-    log, LogLevel, init_step_progress, update_step_progress,
-    finish_step_progress, create_spinner, set_stage, ProcessingStage
+    create_spinner, finish_step_progress, init_step_progress, log, set_stage, update_step_progress,
+    LogLevel, ProcessingStage,
 };
+use crate::transcripts::TranscriptAnnotationCDS;
 
 use flate2::read::MultiGzDecoder;
 use std::collections::{HashMap, HashSet};
@@ -17,8 +17,11 @@ pub fn parse_regions_file(
 ) -> Result<HashMap<String, Vec<ZeroBasedHalfOpen>>, VcfError> {
     set_stage(ProcessingStage::Global);
     let is_bed_file = path.extension().and_then(|s| s.to_str()) == Some("bed");
-    
-    log(LogLevel::Info, &format!("Parsing regions file: {}", path.display()));
+
+    log(
+        LogLevel::Info,
+        &format!("Parsing regions file: {}", path.display()),
+    );
 
     let file = File::open(path)?;
     let reader = BufReader::new(file);
@@ -76,7 +79,10 @@ pub fn parse_regions_file(
     }
 
     let num_regions: usize = regions.values().map(|v| v.len()).sum();
-    log(LogLevel::Info, &format!("Completed parsing {} regions", num_regions));
+    log(
+        LogLevel::Info,
+        &format!("Completed parsing {} regions", num_regions),
+    );
 
     Ok(regions)
 }
@@ -84,8 +90,11 @@ pub fn parse_regions_file(
 // Check 0-based vs. 1 based, half-open vs. inclusive, between config file and mask/allow file
 pub fn parse_config_file(path: &Path) -> Result<Vec<ConfigEntry>, VcfError> {
     set_stage(ProcessingStage::Global);
-    log(LogLevel::Info, &format!("Parsing config file: {}", path.display()));
-    
+    log(
+        LogLevel::Info,
+        &format!("Parsing config file: {}", path.display()),
+    );
+
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b'\t')
         .from_path(path)
@@ -193,10 +202,13 @@ pub fn parse_config_file(path: &Path) -> Result<Vec<ConfigEntry>, VcfError> {
         }
 
         if samples_unfiltered.is_empty() {
-            log(LogLevel::Warning, &format!(
-                "No valid genotypes found for region {}:{}-{}",
-                seqname, start_pos, end_pos
-            ));
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "No valid genotypes found for region {}:{}-{}",
+                    seqname, start_pos, end_pos
+                ),
+            );
             continue;
         }
 
@@ -240,13 +252,19 @@ pub fn parse_region(region: &str) -> Result<ZeroBasedHalfOpen, VcfError> {
     Ok(interval)
 }
 
-
 pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
     set_stage(ProcessingStage::Global);
-    log(LogLevel::Info, &format!("Searching for VCF file for chromosome {} in folder: {}", chr, folder));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Searching for VCF file for chromosome {} in folder: {}",
+            chr, folder
+        ),
+    );
 
     // Use a static flag to only show one VCF spinner at a time
-    static VCF_SPINNER_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    static VCF_SPINNER_ACTIVE: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
     let spinner = if !VCF_SPINNER_ACTIVE.swap(true, std::sync::atomic::Ordering::SeqCst) {
         // First spinner shows general message
         create_spinner("Loading VCF files")
@@ -261,25 +279,25 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
     let path = Path::new(folder);
     if !path.exists() {
         spinner.finish_and_clear();
-        log(LogLevel::Error, &format!(
-            "Error: Folder not found: {}",
-            folder
-        ));
+        log(
+            LogLevel::Error,
+            &format!("Error: Folder not found: {}", folder),
+        );
         return Err(VcfError::Io(io::Error::new(
             io::ErrorKind::NotFound,
-            format!("VCF folder does not exist: {}", folder)
+            format!("VCF folder does not exist: {}", folder),
         )));
     }
-    
+
     if !path.is_dir() {
         spinner.finish_and_clear();
-        log(LogLevel::Error, &format!(
-            "Error: Not a directory: {}",
-            folder
-        ));
+        log(
+            LogLevel::Error,
+            &format!("Error: Not a directory: {}", folder),
+        );
         return Err(VcfError::Io(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("VCF path is not a directory: {}", folder)
+            format!("VCF path is not a directory: {}", folder),
         )));
     }
 
@@ -294,41 +312,46 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         format!("{}.vcf.gz", chr),
         format!("{}.vcf", chr),
     ];
-    
-    spinner.set_message(format!("Searching for chromosome {} using standard patterns", chr));
-    
+
+    spinner.set_message(format!(
+        "Searching for chromosome {} using standard patterns",
+        chr
+    ));
+
     // Try exact match first
     for pattern in common_patterns {
         // Use glob for pattern matching
         let glob_pattern = format!("{}/{}", folder, pattern);
         if let Ok(glob_paths) = glob::glob(&glob_pattern) {
-            let matches: Vec<_> = glob_paths
-                .filter_map(Result::ok)
-                .collect();
+            let matches: Vec<_> = glob_paths.filter_map(Result::ok).collect();
             if !matches.is_empty() {
                 let file_path = &matches[0];
                 spinner.finish_and_clear();
-                log(LogLevel::Info, &format!(
-                    "Found VCF file: {}",
-                    file_path.display()
-                ));
-                log(LogLevel::Info, &format!("Found VCF file using pattern '{}': {}", pattern, file_path.display()));
+                log(
+                    LogLevel::Info,
+                    &format!("Found VCF file: {}", file_path.display()),
+                );
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Found VCF file using pattern '{}': {}",
+                        pattern,
+                        file_path.display()
+                    ),
+                );
                 return Ok(file_path.clone());
             }
         }
     }
-    
+
     // If exact patterns didn't work, try more flexible search
     spinner.set_message(format!("Searching for chromosome {} files", chr));
-    
+
     let entries = match fs::read_dir(path) {
         Ok(entries) => entries,
         Err(e) => {
             spinner.finish_and_clear();
-            log(LogLevel::Error, &format!(
-                "Error reading directory: {}",
-                e
-            ));
+            log(LogLevel::Error, &format!("Error reading directory: {}", e));
             return Err(VcfError::Io(e));
         }
     };
@@ -339,20 +362,22 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         .map(|entry| entry.path())
         .filter(|path| {
             let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            
+
             // Check if it's a valid VCF file (has .vcf or .vcf.gz extension)
             let is_vcf = vcf_extensions.iter().any(|ext| file_name.ends_with(ext));
-            
+
             // Ensure it's not an index or other auxiliary file
-            let not_auxiliary = !invalid_extensions.iter().any(|ext| file_name.ends_with(ext));
-            
+            let not_auxiliary = !invalid_extensions
+                .iter()
+                .any(|ext| file_name.ends_with(ext));
+
             // Check chromosome match
             let chr_pattern = format!("chr{}", chr);
-            let has_chr = file_name.starts_with(&chr_pattern) || 
-                          file_name.starts_with(chr) ||
-                          file_name.contains(&format!("_{}", chr)) ||
-                          file_name.contains(&format!("_{}_", chr));
-            
+            let has_chr = file_name.starts_with(&chr_pattern)
+                || file_name.starts_with(chr)
+                || file_name.contains(&format!("_{}", chr))
+                || file_name.contains(&format!("_{}_", chr));
+
             is_vcf && not_auxiliary && has_chr
         })
         .map(|path| {
@@ -361,39 +386,52 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
             let mut score: i32 = 0;
 
             // Prioritize standard naming patterns
-            if file_name == format!("chr{}.vcf.gz", chr) { score += 100; }
-            else if file_name == format!("chr{}.vcf", chr) { score += 90; }
-            else if file_name == format!("{}.vcf.gz", chr) { score += 80; }
-            else if file_name == format!("{}.vcf", chr) { score += 70; }
-            
+            if file_name == format!("chr{}.vcf.gz", chr) {
+                score += 100;
+            } else if file_name == format!("chr{}.vcf", chr) {
+                score += 90;
+            } else if file_name == format!("{}.vcf.gz", chr) {
+                score += 80;
+            } else if file_name == format!("{}.vcf", chr) {
+                score += 70;
+            }
+
             // Prefer compressed VCF files
-            if file_name.ends_with(".vcf.gz") { score += 15; }
-            
+            if file_name.ends_with(".vcf.gz") {
+                score += 15;
+            }
+
             // Prefer files with standard chromosome nomenclature
-            if file_name.starts_with(&format!("chr{}", chr)) { score += 10; }
-            else if file_name.starts_with(chr) { score += 5; }
-            
+            if file_name.starts_with(&format!("chr{}", chr)) {
+                score += 10;
+            } else if file_name.starts_with(chr) {
+                score += 5;
+            }
+
             // Penalize complex filenames (but not too much)
             score -= (file_name.len() / 5) as i32;
-            
+
             (path, score)
         })
         .collect();
-    
+
     // Sort by score (highest first)
     vcf_candidates.sort_by(|a, b| b.1.cmp(&a.1));
 
     if vcf_candidates.is_empty() {
         // No VCF files found for the specified chromosome
-        log(LogLevel::Warning, &format!(
-            "No VCF files found for chr{}",
-            chr
-        ));
-        log(LogLevel::Error, &format!(
-            "Could not find VCF files for chromosome {} in folder: {}", 
-            chr, folder
-        ));
-        
+        log(
+            LogLevel::Warning,
+            &format!("No VCF files found for chr{}", chr),
+        );
+        log(
+            LogLevel::Error,
+            &format!(
+                "Could not find VCF files for chromosome {} in folder: {}",
+                chr, folder
+            ),
+        );
+
         // Check if any VCF files exist to provide helpful error message
         let any_vcf_files: Vec<_> = fs::read_dir(path)
             .unwrap_or_else(|_| fs::read_dir(".").unwrap())
@@ -401,11 +439,11 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
             .filter(|entry| {
                 let file_name = entry.file_name();
                 let name = file_name.to_string_lossy();
-                vcf_extensions.iter().any(|ext| name.ends_with(ext)) &&
-                !invalid_extensions.iter().any(|ext| name.ends_with(ext))
+                vcf_extensions.iter().any(|ext| name.ends_with(ext))
+                    && !invalid_extensions.iter().any(|ext| name.ends_with(ext))
             })
             .collect();
-            
+
         if any_vcf_files.is_empty() {
             log(LogLevel::Error, &format!(
                 "No VCF files found in directory {}. Please check path is correct and contains VCF files.", 
@@ -414,27 +452,35 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         } else {
             log(LogLevel::Info, "Available VCF files in directory:");
             for file in any_vcf_files.iter().take(5) {
-                log(LogLevel::Info, &format!("  - {}", file.file_name().to_string_lossy()));
+                log(
+                    LogLevel::Info,
+                    &format!("  - {}", file.file_name().to_string_lossy()),
+                );
             }
             if any_vcf_files.len() > 5 {
-                log(LogLevel::Info, &format!("  ... and {} more", any_vcf_files.len() - 5));
+                log(
+                    LogLevel::Info,
+                    &format!("  ... and {} more", any_vcf_files.len() - 5),
+                );
             }
         }
-        
+
         Err(VcfError::NoVcfFiles)
     } else {
         // Select the highest scoring VCF file automatically
         let best_match = &vcf_candidates[0].0;
         spinner.finish_and_clear();
-        log(LogLevel::Info, &format!(
-            "Selected VCF file: {}",
-            best_match.display()
-        ));
-        log(LogLevel::Info, &format!("Selected best matching VCF file: {}", best_match.display()));
+        log(
+            LogLevel::Info,
+            &format!("Selected VCF file: {}", best_match.display()),
+        );
+        log(
+            LogLevel::Info,
+            &format!("Selected best matching VCF file: {}", best_match.display()),
+        );
         return Ok(best_match.clone());
     }
 }
-
 
 pub fn open_vcf_reader(path: &Path) -> Result<Box<dyn BufRead + Send>, VcfError> {
     let file = File::open(path)?;
@@ -471,19 +517,22 @@ pub fn read_reference_sequence(
 ) -> Result<Vec<u8>, VcfError> {
     set_stage(ProcessingStage::Global);
     // Log to file but don't create detailed spinner messages
-    log(LogLevel::Info, &format!(
-        "Reading reference sequence for chromosome {} from {}:{}-{}", 
-        chr, fasta_path.display(), region.start, region.end
-    ));
-    
+    log(
+        LogLevel::Info,
+        &format!(
+            "Reading reference sequence for chromosome {} from {}:{}-{}",
+            chr,
+            fasta_path.display(),
+            region.start,
+            region.end
+        ),
+    );
+
     // Create reader for the FASTA file and its index
     let mut reader = bio::io::fasta::IndexedReader::from_file(&fasta_path).map_err(|e| {
         let error_msg = format!("Failed to open FASTA file: {}", e);
         log(LogLevel::Error, &error_msg);
-        VcfError::Io(io::Error::new(
-            io::ErrorKind::Other,
-            error_msg,
-        ))
+        VcfError::Io(io::Error::new(io::ErrorKind::Other, error_msg))
     })?;
 
     // Try both with and without "chr" prefix
@@ -562,14 +611,20 @@ pub fn read_reference_sequence(
         .collect();
 
     if !invalid_chars.is_empty() {
-        log(LogLevel::Warning, "Found invalid characters in reference sequence:");
+        log(
+            LogLevel::Warning,
+            "Found invalid characters in reference sequence:",
+        );
         for (pos, ch) in invalid_chars {
-            log(LogLevel::Warning, &format!(
-                "Position {}: '{}' (ASCII: {})",
-                pos,
-                String::from_utf8_lossy(&[ch]),
-                ch
-            ));
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "Position {}: '{}' (ASCII: {})",
+                    pos,
+                    String::from_utf8_lossy(&[ch]),
+                    ch
+                ),
+            );
         }
         return Err(VcfError::Parse(format!(
             "Invalid nucleotides found in sequence for region {}:{}-{}",
@@ -577,10 +632,16 @@ pub fn read_reference_sequence(
         )));
     }
 
-    log(LogLevel::Info, &format!(
-        "Completed reading reference sequence: {}bp for chr{}:{}-{}", 
-        sequence.len(), chr, clamped_start, clamped_end
-    ));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Completed reading reference sequence: {}bp for chr{}:{}-{}",
+            sequence.len(),
+            chr,
+            clamped_start,
+            clamped_end
+        ),
+    );
 
     Ok(sequence)
 }
@@ -588,300 +649,345 @@ pub fn read_reference_sequence(
 // Helper function to parse GTF file and extract best CDS regions for each gene
 // GTF and GFF use 1-based coordinate system
 // Returns one TranscriptAnnotationCDS per gene (the best transcript according to priority rules)
-pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnotationCDS>, VcfError> {
-   set_stage(ProcessingStage::Global);
-   log(LogLevel::Info, &format!("Parsing GTF file for chromosome: {}", chr));
-   
-   init_step_progress(&format!("Parsing GTF file for chr{}", chr), 3);
-   
-   // Open the GTF file.
-   let file = File::open(gtf_path).map_err(|e| {
-       let error_msg = format!("GTF file not found: {:?}", e);
-       log(LogLevel::Error, &error_msg);
-       VcfError::Io(io::Error::new(
-           io::ErrorKind::NotFound,
-           error_msg,
-       ))
-   })?;
-   let reader = BufReader::new(file);
+pub fn parse_gtf_file(
+    gtf_path: &Path,
+    chr: &str,
+) -> Result<Vec<TranscriptAnnotationCDS>, VcfError> {
+    set_stage(ProcessingStage::Global);
+    log(
+        LogLevel::Info,
+        &format!("Parsing GTF file for chromosome: {}", chr),
+    );
 
-   // Define priority order for transcript tags
-   // Lower index = higher priority
-   const PRIORITY_TAGS: [&str; 7] = [
-       "MANE_Select",
-       "MANE_Plus_Clinical",
-       "CCDS",
-       "appris_principal_1",
-       "GENCODE_Primary",
-       "Ensembl_canonical",
-       "basic",
-   ];
+    init_step_progress(&format!("Parsing GTF file for chr{}", chr), 3);
 
-   // Structure to hold transcript information for selection
-   #[derive(Default)]
-   struct TranscriptInfo {
-       segments: Vec<(i64, i64, char, i64)>, // start, end, strand, frame
-       priority_level: usize,                // Lower is higher priority (usize::MAX = no priority tag)
-       cds_length: i64,                      // Total length of all CDS segments
-       gene_id: String,                      // Gene this transcript belongs to
-       gene_name: Option<String>,            // Optional gene name
-   }
+    // Open the GTF file.
+    let file = File::open(gtf_path).map_err(|e| {
+        let error_msg = format!("GTF file not found: {:?}", e);
+        log(LogLevel::Error, &error_msg);
+        VcfError::Io(io::Error::new(io::ErrorKind::NotFound, error_msg))
+    })?;
+    let reader = BufReader::new(file);
 
-   // Map of transcript_id -> transcript info
-   let mut transcript_info_map: HashMap<String, TranscriptInfo> = HashMap::new();
-   
-   // Track statistics for logging
-   let mut skipped_lines = 0;
-   let mut processed_lines = 0;
-   let mut transcripts_found = HashSet::new();
-   let mut genes_found = HashSet::new();
-   let mut malformed_attributes = 0;
+    // Define priority order for transcript tags
+    // Lower index = higher priority
+    const PRIORITY_TAGS: [&str; 7] = [
+        "MANE_Select",
+        "MANE_Plus_Clinical",
+        "CCDS",
+        "appris_principal_1",
+        "GENCODE_Primary",
+        "Ensembl_canonical",
+        "basic",
+    ];
 
-   update_step_progress(0, &format!("Reading GTF entries for chr{}", chr));
-   log(LogLevel::Info, "Starting to read GTF entries");
+    // Structure to hold transcript information for selection
+    #[derive(Default)]
+    struct TranscriptInfo {
+        segments: Vec<(i64, i64, char, i64)>, // start, end, strand, frame
+        priority_level: usize, // Lower is higher priority (usize::MAX = no priority tag)
+        cds_length: i64,       // Total length of all CDS segments
+        gene_id: String,       // Gene this transcript belongs to
+        gene_name: Option<String>, // Optional gene name
+    }
 
-   // Read each line, parse if CDS, and store in transcript_info_map
-   for (line_num, line_result) in reader.lines().enumerate() {
-       let line = line_result?;
-       if line.starts_with('#') {
-           continue;
-       }
+    // Map of transcript_id -> transcript info
+    let mut transcript_info_map: HashMap<String, TranscriptInfo> = HashMap::new();
 
-       let fields: Vec<&str> = line.split('\t').collect();
-       if fields.len() < 9 {
-           skipped_lines += 1;
-           continue;
-       }
+    // Track statistics for logging
+    let mut skipped_lines = 0;
+    let mut processed_lines = 0;
+    let mut transcripts_found = HashSet::new();
+    let mut genes_found = HashSet::new();
+    let mut malformed_attributes = 0;
 
-       let seqname = fields[0].trim().trim_start_matches("chr");
-       if seqname != chr.trim_start_matches("chr") {
-           continue;
-       }
+    update_step_progress(0, &format!("Reading GTF entries for chr{}", chr));
+    log(LogLevel::Info, "Starting to read GTF entries");
 
-       // Only process CDS features.
-       if fields[2] != "CDS" {
-           continue;
-       }
+    // Read each line, parse if CDS, and store in transcript_info_map
+    for (line_num, line_result) in reader.lines().enumerate() {
+        let line = line_result?;
+        if line.starts_with('#') {
+            continue;
+        }
 
-       processed_lines += 1;
-       if processed_lines % 10000 == 0 {
-           update_step_progress(0, &format!("Processed {} CDS entries for chr{}", processed_lines, chr));
-           log(LogLevel::Info, &format!("Processed {} CDS entries", processed_lines));
-       }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 9 {
+            skipped_lines += 1;
+            continue;
+        }
 
-       let start: i64 = match fields[3].parse() {
-           Ok(s) => s,
-           Err(_) => {
-               eprintln!(
-                   "Warning: Invalid start position at line {}, skipping",
-                   line_num + 1
-               );
-               skipped_lines += 1;
-               continue;
-           }
-       };
+        let seqname = fields[0].trim().trim_start_matches("chr");
+        if seqname != chr.trim_start_matches("chr") {
+            continue;
+        }
 
-       let end: i64 = match fields[4].parse() {
-           Ok(e) => e,
-           Err(_) => {
-               eprintln!(
-                   "Warning: Invalid end position at line {}, skipping",
-                   line_num + 1
-               );
-               skipped_lines += 1;
-               continue;
-           }
-       };
+        // Only process CDS features.
+        if fields[2] != "CDS" {
+            continue;
+        }
 
-       let strand_char = fields[6].chars().next().unwrap_or('.');
-       let frame: i64 = fields[7].parse().unwrap_or_else(|_| {
-           eprintln!("Warning: Invalid frame at line {}, using 0", line_num + 1);
-           0
-       });
+        processed_lines += 1;
+        if processed_lines % 10000 == 0 {
+            update_step_progress(
+                0,
+                &format!("Processed {} CDS entries for chr{}", processed_lines, chr),
+            );
+            log(
+                LogLevel::Info,
+                &format!("Processed {} CDS entries", processed_lines),
+            );
+        }
 
-       // Parse attributes to find transcript_id, gene_id, gene_name, and priority tags
-       let attributes = fields[8];
-       let mut transcript_id = None;
-       let mut gene_id = None;
-       let mut gene_name = None;
-       let mut found_tags = Vec::new();
-       let mut gene_type = None;
-       let mut transcript_type = None;
+        let start: i64 = match fields[3].parse() {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!(
+                    "Warning: Invalid start position at line {}, skipping",
+                    line_num + 1
+                );
+                skipped_lines += 1;
+                continue;
+            }
+        };
 
-       for attr in attributes.split(';') {
-           let attr = attr.trim();
-           if attr.is_empty() {
-               continue;
-           }
+        let end: i64 = match fields[4].parse() {
+            Ok(e) => e,
+            Err(_) => {
+                eprintln!(
+                    "Warning: Invalid end position at line {}, skipping",
+                    line_num + 1
+                );
+                skipped_lines += 1;
+                continue;
+            }
+        };
 
-           let parts: Vec<&str> = if attr.contains('=') {
-               attr.splitn(2, '=').collect()
-           } else {
-               attr.splitn(2, ' ').collect()
-           };
+        let strand_char = fields[6].chars().next().unwrap_or('.');
+        let frame: i64 = fields[7].parse().unwrap_or_else(|_| {
+            eprintln!("Warning: Invalid frame at line {}, using 0", line_num + 1);
+            0
+        });
 
-           if parts.len() != 2 {
-               continue;
-           }
+        // Parse attributes to find transcript_id, gene_id, gene_name, and priority tags
+        let attributes = fields[8];
+        let mut transcript_id = None;
+        let mut gene_id = None;
+        let mut gene_name = None;
+        let mut found_tags = Vec::new();
+        let mut gene_type = None;
+        let mut transcript_type = None;
 
-           let key = parts[0].trim();
-           let value = parts[1].trim().trim_matches('"').trim_matches('\'');
+        for attr in attributes.split(';') {
+            let attr = attr.trim();
+            if attr.is_empty() {
+                continue;
+            }
 
-           match key {
-               "transcript_id" => transcript_id = Some(value.to_string()),
-               "gene_id" => gene_id = Some(value.to_string()),
-               "gene_name" => gene_name = Some(value.to_string()),
-               "gene_type" => gene_type = Some(value.to_string()),
-               "transcript_type" => transcript_type = Some(value.to_string()),
-               "tag" => found_tags.push(value.to_string()),
-               _ => {}
-           }
-       }
+            let parts: Vec<&str> = if attr.contains('=') {
+                attr.splitn(2, '=').collect()
+            } else {
+                attr.splitn(2, ' ').collect()
+            };
 
-       // Skip non-protein-coding features if we can determine type
-       if let Some(ref gt) = gene_type {
-           if gt != "protein_coding" {
-               continue;
-           }
-       }
-       if let Some(ref tt) = transcript_type {
-           if tt != "protein_coding" {
-               continue;
-           }
-       }
+            if parts.len() != 2 {
+                continue;
+            }
 
-       // Get transcript ID or skip if missing
-       let transcript_id = match transcript_id {
-           Some(id) => id,
-           None => {
-               malformed_attributes += 1;
-               if malformed_attributes <= 5 {
-                   log(LogLevel::Warning, &format!(
-                       "Could not find transcript_id in attributes at line {}: {}",
-                       line_num + 1,
-                       attributes
-                   ));
-               }
-               continue;
-           }
-       };
+            let key = parts[0].trim();
+            let value = parts[1].trim().trim_matches('"').trim_matches('\'');
 
-       // Get gene ID or skip if missing
-       let gene_id = match gene_id {
-           Some(id) => id,
-           None => {
-               malformed_attributes += 1;
-               if malformed_attributes <= 5 {
-                   log(LogLevel::Warning, &format!(
-                       "Could not find gene_id in attributes at line {}: {}",
-                       line_num + 1,
-                       attributes
-                   ));
-               }
-               continue;
-           }
-       };
+            match key {
+                "transcript_id" => transcript_id = Some(value.to_string()),
+                "gene_id" => gene_id = Some(value.to_string()),
+                "gene_name" => gene_name = Some(value.to_string()),
+                "gene_type" => gene_type = Some(value.to_string()),
+                "transcript_type" => transcript_type = Some(value.to_string()),
+                "tag" => found_tags.push(value.to_string()),
+                _ => {}
+            }
+        }
 
-       // Track stats
-       genes_found.insert(gene_id.clone());
-       if let Some(ref gene) = gene_name {
-           transcripts_found.insert(format!("{}:{}", gene, transcript_id));
-       } else {
-           transcripts_found.insert(transcript_id.clone());
-       }
+        // Skip non-protein-coding features if we can determine type
+        if let Some(ref gt) = gene_type {
+            if gt != "protein_coding" {
+                continue;
+            }
+        }
+        if let Some(ref tt) = transcript_type {
+            if tt != "protein_coding" {
+                continue;
+            }
+        }
 
-       // Calculate CDS segment length
-       let segment_length = end - start + 1;
-       
-       // Determine priority level based on tags
-       let priority_level = found_tags.iter()
-           .filter_map(|tag| PRIORITY_TAGS.iter().position(|&p| p == tag))
-           .min()
-           .unwrap_or(usize::MAX); // Use MAX value if no priority tag found
+        // Get transcript ID or skip if missing
+        let transcript_id = match transcript_id {
+            Some(id) => id,
+            None => {
+                malformed_attributes += 1;
+                if malformed_attributes <= 5 {
+                    log(
+                        LogLevel::Warning,
+                        &format!(
+                            "Could not find transcript_id in attributes at line {}: {}",
+                            line_num + 1,
+                            attributes
+                        ),
+                    );
+                }
+                continue;
+            }
+        };
 
-       // Get existing transcript info or create a new one
-       let transcript_info = transcript_info_map.entry(transcript_id.clone()).or_insert_with(|| {
-           TranscriptInfo {
-               segments: Vec::new(),
-               priority_level,
-               cds_length: 0,
-               gene_id: gene_id.clone(),
-               gene_name: gene_name.clone(),
-           }
-       });
+        // Get gene ID or skip if missing
+        let gene_id = match gene_id {
+            Some(id) => id,
+            None => {
+                malformed_attributes += 1;
+                if malformed_attributes <= 5 {
+                    log(
+                        LogLevel::Warning,
+                        &format!(
+                            "Could not find gene_id in attributes at line {}: {}",
+                            line_num + 1,
+                            attributes
+                        ),
+                    );
+                }
+                continue;
+            }
+        };
 
-       // Update the transcript info
-       transcript_info.segments.push((start, end, strand_char, frame));
-       transcript_info.cds_length += segment_length;
-       
-       // Update priority level if we found a better one
-       if priority_level < transcript_info.priority_level {
-           transcript_info.priority_level = priority_level;
-       }
+        // Track stats
+        genes_found.insert(gene_id.clone());
+        if let Some(ref gene) = gene_name {
+            transcripts_found.insert(format!("{}:{}", gene, transcript_id));
+        } else {
+            transcripts_found.insert(transcript_id.clone());
+        }
 
-       // Make sure gene_id is consistent (should be the same for all segments of a transcript)
-       if transcript_info.gene_id != gene_id {
-           log(LogLevel::Warning, &format!(
-               "Inconsistent gene_id for transcript {} at line {}: {} vs {}",
-               transcript_id, line_num + 1, transcript_info.gene_id, gene_id
-           ));
-           // Keep the first gene_id we encountered
-       }
+        // Calculate CDS segment length
+        let segment_length = end - start + 1;
 
-       // Set gene_name if we didn't have it before
-       if transcript_info.gene_name.is_none() && gene_name.is_some() {
-           transcript_info.gene_name = gene_name;
-       }
-   }
+        // Determine priority level based on tags
+        let priority_level = found_tags
+            .iter()
+            .filter_map(|tag| PRIORITY_TAGS.iter().position(|&p| p == tag))
+            .min()
+            .unwrap_or(usize::MAX); // Use MAX value if no priority tag found
 
-   // Print summary of how many lines, transcripts, genes, etc.
-   update_step_progress(1, "Building transcript database");
-   log(LogLevel::Info, "Finished reading GTF file");
-   log(LogLevel::Info, &format!("Total CDS entries processed: {}", processed_lines));
-   log(LogLevel::Info, &format!("Skipped lines: {}", skipped_lines));
-   log(LogLevel::Info, &format!("Unique transcripts found: {}", transcripts_found.len()));
-   log(LogLevel::Info, &format!("Unique genes found: {}", genes_found.len()));
-   if malformed_attributes > 0 {
-       log(LogLevel::Warning, &format!(
-           "Entries with missing required attributes: {}",
-           malformed_attributes
-       ));
-   }
+        // Get existing transcript info or create a new one
+        let transcript_info = transcript_info_map
+            .entry(transcript_id.clone())
+            .or_insert_with(|| TranscriptInfo {
+                segments: Vec::new(),
+                priority_level,
+                cds_length: 0,
+                gene_id: gene_id.clone(),
+                gene_name: gene_name.clone(),
+            });
 
-   // Group transcripts by gene_id
-   let mut gene_to_transcripts: HashMap<String, Vec<String>> = HashMap::new();
-   for (transcript_id, info) in &transcript_info_map {
-       gene_to_transcripts
-           .entry(info.gene_id.clone())
-           .or_default()
-           .push(transcript_id.clone());
-   }
+        // Update the transcript info
+        transcript_info
+            .segments
+            .push((start, end, strand_char, frame));
+        transcript_info.cds_length += segment_length;
 
-   log(LogLevel::Info, "Starting to select best transcript for each gene");
-   
+        // Update priority level if we found a better one
+        if priority_level < transcript_info.priority_level {
+            transcript_info.priority_level = priority_level;
+        }
+
+        // Make sure gene_id is consistent (should be the same for all segments of a transcript)
+        if transcript_info.gene_id != gene_id {
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "Inconsistent gene_id for transcript {} at line {}: {} vs {}",
+                    transcript_id,
+                    line_num + 1,
+                    transcript_info.gene_id,
+                    gene_id
+                ),
+            );
+            // Keep the first gene_id we encountered
+        }
+
+        // Set gene_name if we didn't have it before
+        if transcript_info.gene_name.is_none() && gene_name.is_some() {
+            transcript_info.gene_name = gene_name;
+        }
+    }
+
+    // Print summary of how many lines, transcripts, genes, etc.
+    update_step_progress(1, "Building transcript database");
+    log(LogLevel::Info, "Finished reading GTF file");
+    log(
+        LogLevel::Info,
+        &format!("Total CDS entries processed: {}", processed_lines),
+    );
+    log(LogLevel::Info, &format!("Skipped lines: {}", skipped_lines));
+    log(
+        LogLevel::Info,
+        &format!("Unique transcripts found: {}", transcripts_found.len()),
+    );
+    log(
+        LogLevel::Info,
+        &format!("Unique genes found: {}", genes_found.len()),
+    );
+    if malformed_attributes > 0 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Entries with missing required attributes: {}",
+                malformed_attributes
+            ),
+        );
+    }
+
+    // Group transcripts by gene_id
+    let mut gene_to_transcripts: HashMap<String, Vec<String>> = HashMap::new();
+    for (transcript_id, info) in &transcript_info_map {
+        gene_to_transcripts
+            .entry(info.gene_id.clone())
+            .or_default()
+            .push(transcript_id.clone());
+    }
+
+    log(
+        LogLevel::Info,
+        "Starting to select best transcript for each gene",
+    );
+
     // For each gene, select the best transcript based on priority rules
     let mut best_transcripts = HashSet::new();
     for (gene_id, transcript_ids) in gene_to_transcripts {
-        log(LogLevel::Debug, &format!("Selecting best transcript for gene: {}", gene_id));
+        log(
+            LogLevel::Debug,
+            &format!("Selecting best transcript for gene: {}", gene_id),
+        );
         if transcript_ids.is_empty() {
             continue;
         }
 
-       // Find transcript with highest priority (lowest priority_level)
-       let min_priority = transcript_ids.iter()
-           .filter_map(|tid| transcript_info_map.get(tid))
-           .map(|info| info.priority_level)
-           .min()
-           .unwrap_or(usize::MAX);
+        // Find transcript with highest priority (lowest priority_level)
+        let min_priority = transcript_ids
+            .iter()
+            .filter_map(|tid| transcript_info_map.get(tid))
+            .map(|info| info.priority_level)
+            .min()
+            .unwrap_or(usize::MAX);
 
-       // Get all transcripts with this priority level
-       let candidates: Vec<&String> = transcript_ids.iter()
-           .filter(|tid| {
-               transcript_info_map.get(*tid)
-                   .map(|info| info.priority_level == min_priority)
-                   .unwrap_or(false)
-           })
-           .collect();
+        // Get all transcripts with this priority level
+        let candidates: Vec<&String> = transcript_ids
+            .iter()
+            .filter(|tid| {
+                transcript_info_map
+                    .get(*tid)
+                    .map(|info| info.priority_level == min_priority)
+                    .unwrap_or(false)
+            })
+            .collect();
 
         // When multiple transcripts have the same priority,
         // choose the one with the longest coding sequence length.
@@ -891,7 +997,8 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
             candidates[0].clone()
         } else {
             // For multiple candidates, find the longest CDS length among them.
-            let max_length = candidates.iter()
+            let max_length = candidates
+                .iter()
                 // Loop through each transcript ID in the candidates list.
                 .filter_map(|tid| transcript_info_map.get(*tid))
                 // For each ID, look it up in the transcript_info_map to get its details.
@@ -901,70 +1008,77 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
                 .max()
                 // Find the biggest CDS length in the list.
                 .unwrap_or(0);
-                // If something goes wrong and we get no lengths (shouldn’t happen), use 0 as a fallback.
-        
+            // If something goes wrong and we get no lengths (shouldn’t happen), use 0 as a fallback.
+
             // Now, collect all transcript IDs that have this maximum CDS length.
-            let longest_candidates: Vec<&&String> = candidates.iter()
+            let longest_candidates: Vec<&&String> = candidates
+                .iter()
                 // Iterate over references to transcript IDs in candidates.
                 .filter(|tid| {
                     // For each transcript ID reference
-                    transcript_info_map.get(&tid[..])
-                    // Look up its details in the transcript_info_map using a string slice.
-                    .map(|info| info.cds_length == max_length)
-                    // Check if its CDS length matches the maximum found earlier.
-                    .unwrap_or(false)
+                    transcript_info_map
+                        .get(&tid[..])
+                        // Look up its details in the transcript_info_map using a string slice.
+                        .map(|info| info.cds_length == max_length)
+                        // Check if its CDS length matches the maximum found earlier.
+                        .unwrap_or(false)
                     // Return false if the transcript isn’t found in the map.
                 })
                 .collect();
-                // Gather all matching transcript IDs into a vector.
-        
+            // Gather all matching transcript IDs into a vector.
+
             // Pick the best one from the transcripts with the longest CDS.
             // If there’s more than one with the same max length, take the first.
-            longest_candidates.first()
+            longest_candidates
+                .first()
                 // Retrieve the first reference to a transcript ID from longest_candidates.
                 .map(|s| (**s).clone())
                 // Dereference twice to get the String and clone it for the result.
                 .unwrap_or_else(|| candidates[0].clone())
-                // If no longest candidate exists, use the first candidate as a fallback.
+            // If no longest candidate exists, use the first candidate as a fallback.
         };
 
-       best_transcripts.insert(best_transcript);
-   }
+        best_transcripts.insert(best_transcript);
+    }
 
-    log(LogLevel::Info, &format!(
-      "Selected {} best transcripts out of {} total transcripts",
-      best_transcripts.len(), transcript_info_map.len()
-   ));
-   update_step_progress(2, "Building transcript data structures");
+    log(
+        LogLevel::Info,
+        &format!(
+            "Selected {} best transcripts out of {} total transcripts",
+            best_transcripts.len(),
+            transcript_info_map.len()
+        ),
+    );
+    update_step_progress(2, "Building transcript data structures");
 
-   // Now build a vector of TranscriptAnnotationCDS objects, but only for the best transcripts
-   let mut transcripts_vec = Vec::new();
+    // Now build a vector of TranscriptAnnotationCDS objects, but only for the best transcripts
+    let mut transcripts_vec = Vec::new();
 
-   for (tid, info) in transcript_info_map {
-       // Skip if this transcript is not the best for its gene
-       if !best_transcripts.contains(&tid) {
-           continue;
-       }
+    for (tid, info) in transcript_info_map {
+        // Skip if this transcript is not the best for its gene
+        if !best_transcripts.contains(&tid) {
+            continue;
+        }
 
-       // Process segments
-       let mut segments = info.segments;
-       segments.sort_by_key(|&(s, _, _, _)| s);
+        // Process segments
+        let mut segments = info.segments;
+        segments.sort_by_key(|&(s, _, _, _)| s);
 
-       if segments.is_empty() {
-           continue;
-       }
+        if segments.is_empty() {
+            continue;
+        }
 
-       let strand = segments[0].2;
-       if strand == '-' {
-           segments.reverse();
-       }
+        let strand = segments[0].2;
+        if strand == '-' {
+            segments.reverse();
+        }
 
-       let strand_char = segments[0].2;
-       let frames_vec: Vec<i64> = segments.iter().map(|&(_s, _e, _str, f)| f).collect();
-       let seg_intervals: Vec<ZeroBasedHalfOpen> = segments
-           .iter()
-           .map(|&(s, e, _, _)| ZeroBasedHalfOpen::from_1based_inclusive(s, e))
-           .collect();
+        let strand_char = segments[0].2;
+        let frames_vec: Vec<i64> = segments.iter().map(|&(_s, _e, _str, f)| f).collect();
+        let seg_intervals: Vec<ZeroBasedHalfOpen> = segments
+            .iter()
+            .map(|&(s, e, _, _)| ZeroBasedHalfOpen::from_1based_inclusive(s, e))
+            .collect();
 
         transcripts_vec.push(TranscriptAnnotationCDS {
             transcript_id: tid,
@@ -974,21 +1088,28 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
             frames: frames_vec,
             segments: seg_intervals,
         });
-   }
+    }
 
-    log(LogLevel::Info, &format!(
-       "Number of best transcripts returned: {}",
-       transcripts_vec.len()
-   ));
-   if transcripts_vec.is_empty() {
-       log(LogLevel::Warning, &format!("No CDS transcripts parsed for chromosome {}", chr));
-   }
-   
-   finish_step_progress(&format!(
-       "Parsed {} transcripts for chr{}", 
-       transcripts_vec.len(), chr
-   ));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Number of best transcripts returned: {}",
+            transcripts_vec.len()
+        ),
+    );
+    if transcripts_vec.is_empty() {
+        log(
+            LogLevel::Warning,
+            &format!("No CDS transcripts parsed for chromosome {}", chr),
+        );
+    }
 
-   // Return only the best transcript for each gene
-   Ok(transcripts_vec)
+    finish_step_progress(&format!(
+        "Parsed {} transcripts for chr{}",
+        transcripts_vec.len(),
+        chr
+    ));
+
+    // Return only the best transcript for each gene
+    Ok(transcripts_vec)
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -241,6 +241,82 @@ pub struct PopulationContext<'a> {
     /// The effective sequence length (L) for normalization in diversity calculations.
     /// This should account for any masking or specific intervals considered.
     pub sequence_length: i64,
+    pub dense_genotypes: Option<&'a DenseGenotypeMatrix>,
+    pub dense_summary: Option<Arc<DensePopulationSummary>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DenseGenotypeMatrix {
+    data: Arc<[u8]>,
+    missing: Option<Arc<[u64]>>,
+    variant_count: usize,
+    sample_count: usize,
+    ploidy: usize,
+    stride: usize,
+    max_allele: u8,
+}
+
+impl DenseGenotypeMatrix {
+    pub fn new(
+        data: Vec<u8>,
+        missing: Option<Vec<u64>>,
+        variant_count: usize,
+        sample_count: usize,
+        ploidy: usize,
+        max_allele: u8,
+    ) -> Self {
+        debug_assert_eq!(
+            data.len(),
+            variant_count * sample_count * ploidy,
+            "dense genotype matrix requires variants * samples * ploidy entries",
+        );
+        let data = Arc::<[u8]>::from(data.into_boxed_slice());
+        let missing = missing.map(|bits| Arc::<[u64]>::from(bits.into_boxed_slice()));
+        Self {
+            data,
+            missing,
+            variant_count,
+            sample_count,
+            ploidy,
+            stride: sample_count * ploidy,
+            max_allele,
+        }
+    }
+
+    #[inline]
+    pub fn variant_count(&self) -> usize {
+        self.variant_count
+    }
+
+    #[inline]
+    pub fn sample_count(&self) -> usize {
+        self.sample_count
+    }
+
+    #[inline]
+    pub fn ploidy(&self) -> usize {
+        self.ploidy
+    }
+
+    #[inline]
+    fn stride(&self) -> usize {
+        self.stride
+    }
+
+    #[inline]
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    #[inline]
+    fn missing_slice(&self) -> Option<&[u64]> {
+        self.missing.as_deref()
+    }
+
+    #[inline]
+    pub fn max_allele(&self) -> u8 {
+        self.max_allele
+    }
 }
 
 /// Holds the result of a Dxy (between-population nucleotide diversity) calculation,
@@ -844,7 +920,7 @@ const INVALID_GROUP: u16 = u16::MAX;
 struct PairDescriptor {
     left: u16,
     right: u16,
-
+    key: String,
 }
 
 #[derive(Clone)]
@@ -857,7 +933,6 @@ struct SubpopulationMembership {
     /// regardless of which comparisons had sufficient data.
     pair_keys: Vec<PairDescriptor>,
 }
-
 
 impl SubpopulationMembership {
     fn from_map(sample_count: usize, map_subpop: &HashMap<(usize, HaplotypeSide), String>) -> Self {
@@ -994,6 +1069,349 @@ impl HapMembership {
         }
 
         Self { left, right, total }
+    }
+}
+
+#[derive(Clone)]
+struct DenseMembership {
+    offsets: Vec<usize>,
+}
+
+impl DenseMembership {
+    fn build(matrix: &DenseGenotypeMatrix, haplotypes: &[(usize, HaplotypeSide)]) -> Self {
+        let sample_count = matrix.sample_count();
+        let ploidy = matrix.ploidy();
+        let mut left = vec![false; sample_count];
+        let mut right = vec![false; sample_count];
+        let mut offsets = Vec::with_capacity(haplotypes.len());
+
+        for &(sample_idx, side) in haplotypes {
+            if sample_idx >= sample_count {
+                continue;
+            }
+            match side {
+                HaplotypeSide::Left => {
+                    if !left[sample_idx] {
+                        left[sample_idx] = true;
+                        offsets.push(sample_idx * ploidy);
+                    }
+                }
+                HaplotypeSide::Right => {
+                    if ploidy <= 1 {
+                        continue;
+                    }
+                    if !right[sample_idx] {
+                        right[sample_idx] = true;
+                        offsets.push(sample_idx * ploidy + 1);
+                    }
+                }
+            }
+        }
+
+        Self { offsets }
+    }
+
+    #[inline]
+    fn offsets(&self) -> &[usize] {
+        &self.offsets
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+}
+
+#[inline(always)]
+fn dense_missing(bits: &[u64], idx: usize) -> bool {
+    let word = idx >> 6;
+    let bit = idx & 63;
+    unsafe { ((*bits.get_unchecked(word) >> bit) & 1) == 1 }
+}
+
+#[derive(Debug)]
+pub struct DensePopulationSummary {
+    alt_counts: Arc<[u32]>,
+    called_counts: Arc<[u32]>,
+    haplotype_capacity: usize,
+}
+
+impl DensePopulationSummary {
+    #[inline]
+    pub fn alt_counts(&self) -> &[u32] {
+        &self.alt_counts
+    }
+
+    #[inline]
+    pub fn called_counts(&self) -> &[u32] {
+        &self.called_counts
+    }
+
+    #[inline]
+    pub fn haplotype_capacity(&self) -> usize {
+        self.haplotype_capacity
+    }
+}
+
+pub fn build_dense_population_summary(
+    matrix: &DenseGenotypeMatrix,
+    haplotypes: &[(usize, HaplotypeSide)],
+) -> DensePopulationSummary {
+    let membership = DenseMembership::build(matrix, haplotypes);
+    let offsets = membership.offsets();
+    let variant_count = matrix.variant_count();
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut alt_counts = vec![0u32; variant_count];
+    let mut called_counts = vec![0u32; variant_count];
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..variant_count {
+            let base = variant_idx * stride;
+            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            alt_counts[variant_idx] = alt as u32;
+            called_counts[variant_idx] = called as u32;
+        }
+    } else {
+        let total = offsets.len() as u32;
+        for variant_idx in 0..variant_count {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            alt_counts[variant_idx] = alt as u32;
+            called_counts[variant_idx] = total;
+        }
+    }
+
+    DensePopulationSummary {
+        alt_counts: Arc::from(alt_counts.into_boxed_slice()),
+        called_counts: Arc::from(called_counts.into_boxed_slice()),
+        haplotype_capacity: offsets.len(),
+    }
+}
+
+fn count_segregating_sites_from_summary(summary: &DensePopulationSummary) -> usize {
+    summary
+        .alt_counts()
+        .iter()
+        .zip(summary.called_counts())
+        .filter(|(&alt, &called)| {
+            let called = called as usize;
+            let alt = alt as usize;
+            called >= 2 && alt > 0 && alt < called
+        })
+        .count()
+}
+
+fn calculate_pi_from_summary(summary: &DensePopulationSummary, seq_length: i64) -> f64 {
+    if summary.haplotype_capacity() <= 1 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: insufficient haplotypes ({})",
+                summary.haplotype_capacity()
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length < 0 {
+        log(
+            LogLevel::Warning,
+            &format!("Cannot calculate pi: invalid sequence length ({seq_length})"),
+        );
+        return 0.0;
+    }
+
+    if seq_length == 0 {
+        log(
+            LogLevel::Warning,
+            "Cannot calculate pi: zero sequence length causes division by zero",
+        );
+        return f64::INFINITY;
+    }
+
+    let mut sum_pi = 0.0_f64;
+    for (&alt, &called) in summary.alt_counts().iter().zip(summary.called_counts()) {
+        let alt = alt as usize;
+        let called = called as usize;
+        if let Some(pi) = dense_pi_from_counts(called, alt) {
+            sum_pi += pi;
+        }
+    }
+
+    sum_pi / seq_length as f64
+}
+
+fn aggregate_hudson_components_from_summaries(
+    pop1: &DensePopulationSummary,
+    pop2: &DensePopulationSummary,
+) -> (f64, f64) {
+    let len = pop1.alt_counts().len().min(pop2.alt_counts().len());
+    let alt1 = pop1.alt_counts();
+    let alt2 = pop2.alt_counts();
+    let called1 = pop1.called_counts();
+    let called2 = pop2.called_counts();
+    let mut num_sum = 0.0;
+    let mut den_sum = 0.0;
+
+    for idx in 0..len {
+        let n1 = called1[idx] as usize;
+        let alt_count1 = alt1[idx] as usize;
+        let n2 = called2[idx] as usize;
+        let alt_count2 = alt2[idx] as usize;
+
+        let pi1 = dense_pi_from_counts(n1, alt_count1);
+        let pi2 = dense_pi_from_counts(n2, alt_count2);
+        let dxy = dense_dxy_from_biallelic_counts(n1, alt_count1, n2, alt_count2);
+
+        if let (Some(d), Some(p1_val), Some(p2_val)) = (dxy, pi1, pi2) {
+            if d > FST_EPSILON {
+                num_sum += d - 0.5 * (p1_val + p2_val);
+                den_sum += d;
+            } else {
+                let pi_avg = 0.5 * (p1_val + p2_val);
+                if pi_avg.abs() <= FST_EPSILON {
+                    // contributes zero to both sums
+                }
+            }
+        }
+    }
+
+    (num_sum, den_sum)
+}
+
+fn hudson_component_sums(sites: &[SiteFstHudson]) -> (f64, f64) {
+    let mut num_sum = 0.0_f64;
+    let mut den_sum = 0.0_f64;
+    for s in sites {
+        if let (Some(nc), Some(dc)) = (s.num_component, s.den_component) {
+            num_sum += nc;
+            den_sum += dc;
+        }
+    }
+    (num_sum, den_sum)
+}
+
+fn dxy_from_summaries(
+    pop1: &DensePopulationSummary,
+    pop2: &DensePopulationSummary,
+    sequence_length: i64,
+) -> Option<f64> {
+    if sequence_length <= 0 {
+        return None;
+    }
+    let len = pop1.alt_counts().len().min(pop2.alt_counts().len());
+    let alt1 = pop1.alt_counts();
+    let alt2 = pop2.alt_counts();
+    let called1 = pop1.called_counts();
+    let called2 = pop2.called_counts();
+    let mut sum_dxy = 0.0_f64;
+
+    for idx in 0..len {
+        let n1 = called1[idx] as usize;
+        let alt_count1 = alt1[idx] as usize;
+        let n2 = called2[idx] as usize;
+        let alt_count2 = alt2[idx] as usize;
+        if let Some(dxy) = dense_dxy_from_biallelic_counts(n1, alt_count1, n2, alt_count2) {
+            sum_dxy += dxy;
+        }
+    }
+
+    Some(sum_dxy / sequence_length as f64)
+}
+
+#[inline(always)]
+fn dense_sum_alt_no_missing(data: &[u8], base: usize, offsets: &[usize]) -> usize {
+    let mut sum = 0usize;
+    unsafe {
+        let ptr = data.as_ptr().add(base);
+        for &offset in offsets {
+            sum += *ptr.add(offset) as usize;
+        }
+    }
+    sum
+}
+
+#[inline(always)]
+fn dense_sum_alt_with_missing(
+    data: &[u8],
+    base: usize,
+    offsets: &[usize],
+    bits: &[u64],
+) -> (usize, usize) {
+    let mut alt = 0usize;
+    let mut total = 0usize;
+    unsafe {
+        let ptr = data.as_ptr().add(base);
+        for &offset in offsets {
+            let idx = base + offset;
+            if dense_missing(bits, idx) {
+                continue;
+            }
+            alt += *ptr.add(offset) as usize;
+            total += 1;
+        }
+    }
+    (total, alt)
+}
+
+#[inline(always)]
+fn dense_pi_from_counts(total_called: usize, alt_count: usize) -> Option<f64> {
+    if total_called < 2 {
+        return None;
+    }
+    let n = total_called as f64;
+    let alt = alt_count as f64;
+    let ref_count = (total_called - alt_count) as f64;
+    let sum_sq = ref_count * ref_count + alt * alt;
+    Some(n / (n - 1.0) * (1.0 - sum_sq / (n * n)))
+}
+
+#[inline(always)]
+fn dense_dxy_from_biallelic_counts(n1: usize, alt1: usize, n2: usize, alt2: usize) -> Option<f64> {
+    if n1 == 0 || n2 == 0 {
+        return None;
+    }
+    let n1_f = n1 as f64;
+    let n2_f = n2 as f64;
+    let alt1_f = alt1 as f64 / n1_f;
+    let alt2_f = alt2 as f64 / n2_f;
+    let ref1 = 1.0 - alt1_f;
+    let ref2 = 1.0 - alt2_f;
+    let mut dot = ref1 * ref2 + alt1_f * alt2_f;
+    if dot < 0.0 {
+        dot = 0.0;
+    }
+    let mut dxy = 1.0 - dot;
+    if dxy < 0.0 {
+        dxy = 0.0;
+    } else if dxy > 1.0 {
+        dxy = 1.0;
+    }
+    Some(dxy)
+}
+
+#[inline(always)]
+fn dense_fst_components_from_biallelic(
+    dxy: Option<f64>,
+    pi1: Option<f64>,
+    pi2: Option<f64>,
+) -> (Option<f64>, Option<f64>, Option<f64>) {
+    match (dxy, pi1, pi2) {
+        (Some(d), Some(p1), Some(p2)) => {
+            if d > FST_EPSILON {
+                let num = d - 0.5 * (p1 + p2);
+                (Some(num / d), Some(num), Some(d))
+            } else {
+                let pi_avg = 0.5 * (p1 + p2);
+                if pi_avg.abs() <= FST_EPSILON {
+                    (Some(0.0), Some(0.0), Some(0.0))
+                } else {
+                    (None, None, None)
+                }
+            }
+        }
+        _ => (None, None, None),
     }
 }
 
@@ -1198,7 +1616,6 @@ fn calculate_fst_wc_at_site_with_membership(
 
     workspace.stats.clear();
 
-
     (
         overall_fst_at_site,
         pairwise_fst_estimate_map,
@@ -1207,7 +1624,6 @@ fn calculate_fst_wc_at_site_with_membership(
         pairwise_variance_components_map,
     )
 }
-
 
 fn calculate_variance_components(
     pop_stats: &[PopSiteStat], // (n_i, p_i)
@@ -1612,6 +2028,30 @@ pub fn calculate_d_xy_hudson<'a>(
         return Ok(DxyHudsonResult { d_xy: None });
     }
 
+    if let (Some(summary1), Some(summary2)) = (
+        pop1_context.dense_summary.as_deref(),
+        pop2_context.dense_summary.as_deref(),
+    ) {
+        let dxy_value = dxy_from_summaries(summary1, summary2, pop1_context.sequence_length);
+        return Ok(DxyHudsonResult { d_xy: dxy_value });
+    }
+
+    if let (Some(matrix1), Some(matrix2)) =
+        (pop1_context.dense_genotypes, pop2_context.dense_genotypes)
+    {
+        if std::ptr::eq(matrix1, matrix2) && matrix1.ploidy() == 2 {
+            let membership1 = DenseMembership::build(matrix1, &pop1_context.haplotypes);
+            let membership2 = DenseMembership::build(matrix2, &pop2_context.haplotypes);
+            let d_xy_value = calculate_dxy_dense(
+                matrix1,
+                &membership1,
+                &membership2,
+                pop1_context.sequence_length,
+            );
+            return Ok(DxyHudsonResult { d_xy: d_xy_value });
+        }
+    }
+
     // Use unbiased per-site aggregation approach
     let mut sum_dxy = 0.0;
     let mut variant_count = 0;
@@ -1657,6 +2097,79 @@ pub fn calculate_d_xy_hudson<'a>(
     };
 
     Ok(DxyHudsonResult { d_xy: d_xy_value })
+}
+
+fn calculate_dxy_dense(
+    matrix: &DenseGenotypeMatrix,
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+    sequence_length: i64,
+) -> Option<f64> {
+    if pop1_mem.len() == 0 || pop2_mem.len() == 0 {
+        return None;
+    }
+    if sequence_length <= 0 {
+        return None;
+    }
+
+    let mut counts1 = vec![0u32; 256];
+    let mut used1 = Vec::with_capacity(8);
+    let mut counts2 = vec![0u32; 256];
+    let mut used2 = Vec::with_capacity(8);
+    let mut sum_dxy = 0.0_f64;
+
+    for variant_idx in 0..matrix.variant_count() {
+        let (n1, _) = dense_collect_counts(matrix, pop1_mem, variant_idx, &mut counts1, &mut used1);
+        let (n2, _) = dense_collect_counts(matrix, pop2_mem, variant_idx, &mut counts2, &mut used2);
+
+        if n1 == 0 || n2 == 0 {
+            dense_reset_counts(&mut counts1, &mut used1);
+            dense_reset_counts(&mut counts2, &mut used2);
+            continue;
+        }
+
+        let inv1 = 1.0 / n1 as f64;
+        let inv2 = 1.0 / n2 as f64;
+        let mut dot = 0.0_f64;
+        if used1.len() <= used2.len() {
+            for &allele in &used1 {
+                let c1 = counts1[allele];
+                if c1 == 0 {
+                    continue;
+                }
+                let c2 = if allele < counts2.len() {
+                    counts2[allele]
+                } else {
+                    0
+                };
+                if c2 != 0 {
+                    dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                }
+            }
+        } else {
+            for &allele in &used2 {
+                let c2 = counts2[allele];
+                if c2 == 0 {
+                    continue;
+                }
+                let c1 = if allele < counts1.len() {
+                    counts1[allele]
+                } else {
+                    0
+                };
+                if c1 != 0 {
+                    dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                }
+            }
+        }
+        let dxy_site = (1.0 - dot).max(0.0).min(1.0);
+        sum_dxy += dxy_site;
+
+        dense_reset_counts(&mut counts1, &mut used1);
+        dense_reset_counts(&mut counts2, &mut used2);
+    }
+
+    Some(sum_dxy / sequence_length as f64)
 }
 
 /// Extract allele counts for a population at a specific variant site.
@@ -1870,6 +2383,72 @@ fn compute_pi_metrics_fast(
     }
 }
 
+fn dense_collect_counts(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    variant_idx: usize,
+    counts: &mut Vec<u32>,
+    used: &mut Vec<usize>,
+) -> (usize, f64) {
+    let stride = matrix.stride();
+    let base = variant_idx * stride;
+    let data = matrix.data();
+    let offsets = membership.offsets();
+    let total_called = if let Some(bits) = matrix.missing_slice() {
+        let mut called = 0usize;
+        unsafe {
+            let ptr = data.as_ptr();
+            for &offset in offsets {
+                let idx = base + offset;
+                if dense_missing(bits, idx) {
+                    continue;
+                }
+                let allele = *ptr.add(idx) as usize;
+                if allele >= counts.len() {
+                    counts.resize(allele + 1, 0);
+                }
+                if counts[allele] == 0 {
+                    used.push(allele);
+                }
+                counts[allele] += 1;
+                called += 1;
+            }
+        }
+        called
+    } else {
+        unsafe {
+            let ptr = data.as_ptr();
+            for &offset in offsets {
+                let idx = base + offset;
+                let allele = *ptr.add(idx) as usize;
+                if allele >= counts.len() {
+                    counts.resize(allele + 1, 0);
+                }
+                if counts[allele] == 0 {
+                    used.push(allele);
+                }
+                counts[allele] += 1;
+            }
+        }
+        offsets.len()
+    };
+
+    let mut sum_counts_sq = 0.0;
+    for &allele in used.iter() {
+        let count = counts[allele] as f64;
+        sum_counts_sq += count * count;
+    }
+
+    (total_called, sum_counts_sq)
+}
+
+fn dense_reset_counts(counts: &mut Vec<u32>, used: &mut Vec<usize>) {
+    for &idx in used.iter() {
+        counts[idx] = 0;
+    }
+    used.clear();
+}
+
 /// Compute between-population diversity (D_xy) from allele counts.
 ///
 /// Mathematical Foundation:
@@ -2066,6 +2645,226 @@ pub fn calculate_hudson_fst_per_site(
     sites
 }
 
+fn dense_hudson_sites(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    if matrix.max_allele() <= 1 {
+        return dense_hudson_sites_biallelic(matrix, variants, pop1_mem, pop2_mem);
+    }
+    dense_hudson_sites_general(matrix, variants, pop1_mem, pop2_mem)
+}
+
+fn dense_hudson_sites_general(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    let mut counts1 = vec![0u32; 256];
+    let mut used1 = Vec::with_capacity(8);
+    let mut counts2 = vec![0u32; 256];
+    let mut used2 = Vec::with_capacity(8);
+    let mut sites = Vec::with_capacity(variants.len());
+
+    for (variant_idx, variant) in variants.iter().enumerate() {
+        let (n1, sum_sq1) =
+            dense_collect_counts(matrix, pop1_mem, variant_idx, &mut counts1, &mut used1);
+        let (n2, sum_sq2) =
+            dense_collect_counts(matrix, pop2_mem, variant_idx, &mut counts2, &mut used2);
+
+        let pi1 = if n1 >= 2 {
+            let n = n1 as f64;
+            Some(n / (n - 1.0) * (1.0 - sum_sq1 / (n * n)))
+        } else {
+            None
+        };
+        let pi2 = if n2 >= 2 {
+            let n = n2 as f64;
+            Some(n / (n - 1.0) * (1.0 - sum_sq2 / (n * n)))
+        } else {
+            None
+        };
+
+        let dxy = if n1 == 0 || n2 == 0 {
+            None
+        } else {
+            let inv1 = 1.0 / n1 as f64;
+            let inv2 = 1.0 / n2 as f64;
+            let mut dot = 0.0_f64;
+            if used1.len() <= used2.len() {
+                for &allele in &used1 {
+                    let c1 = counts1[allele];
+                    if c1 == 0 {
+                        continue;
+                    }
+                    let c2 = if allele < counts2.len() {
+                        counts2[allele]
+                    } else {
+                        0
+                    };
+                    if c2 != 0 {
+                        dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                    }
+                }
+            } else {
+                for &allele in &used2 {
+                    let c2 = counts2[allele];
+                    if c2 == 0 {
+                        continue;
+                    }
+                    let c1 = if allele < counts1.len() {
+                        counts1[allele]
+                    } else {
+                        0
+                    };
+                    if c1 != 0 {
+                        dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                    }
+                }
+            }
+            Some((1.0 - dot).max(0.0).min(1.0))
+        };
+
+        let (fst, num_component, den_component) = match (dxy, pi1, pi2) {
+            (Some(d), Some(p1), Some(p2)) => {
+                if d > FST_EPSILON {
+                    let num = d - 0.5 * (p1 + p2);
+                    (Some(num / d), Some(num), Some(d))
+                } else {
+                    let pi_avg = 0.5 * (p1 + p2);
+                    if pi_avg.abs() <= FST_EPSILON {
+                        (Some(0.0), Some(0.0), Some(0.0))
+                    } else {
+                        (None, None, None)
+                    }
+                }
+            }
+            _ => (None, None, None),
+        };
+
+        sites.push(SiteFstHudson {
+            position: ZeroBasedPosition(variant.position).to_one_based(),
+            fst,
+            d_xy: dxy,
+            pi_pop1: pi1,
+            pi_pop2: pi2,
+            n1_called: n1,
+            n2_called: n2,
+            num_component,
+            den_component,
+        });
+
+        dense_reset_counts(&mut counts1, &mut used1);
+        dense_reset_counts(&mut counts2, &mut used2);
+    }
+
+    sites
+}
+
+fn dense_hudson_sites_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    let offsets1 = pop1_mem.offsets();
+    let offsets2 = pop2_mem.offsets();
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut sites = Vec::with_capacity(variants.len());
+
+    match matrix.missing_slice() {
+        Some(bits) => {
+            for (variant_idx, variant) in variants.iter().enumerate() {
+                let base = variant_idx * stride;
+                let (n1, alt1) = dense_sum_alt_with_missing(data, base, offsets1, bits);
+                let (n2, alt2) = dense_sum_alt_with_missing(data, base, offsets2, bits);
+
+                let pi1 = dense_pi_from_counts(n1, alt1);
+                let pi2 = dense_pi_from_counts(n2, alt2);
+                let dxy = dense_dxy_from_biallelic_counts(n1, alt1, n2, alt2);
+
+                let (fst, num_component, den_component) =
+                    dense_fst_components_from_biallelic(dxy, pi1, pi2);
+
+                sites.push(SiteFstHudson {
+                    position: ZeroBasedPosition(variant.position).to_one_based(),
+                    fst,
+                    d_xy: dxy,
+                    pi_pop1: pi1,
+                    pi_pop2: pi2,
+                    n1_called: n1,
+                    n2_called: n2,
+                    num_component,
+                    den_component,
+                });
+            }
+        }
+        None => {
+            let n1_total = offsets1.len();
+            let n2_total = offsets2.len();
+            let n1_f = n1_total as f64;
+            let n2_f = n2_total as f64;
+            let scale1 = if n1_total >= 2 {
+                Some((n1_f / (n1_f - 1.0), 1.0 / (n1_f * n1_f)))
+            } else {
+                None
+            };
+            let scale2 = if n2_total >= 2 {
+                Some((n2_f / (n2_f - 1.0), 1.0 / (n2_f * n2_f)))
+            } else {
+                None
+            };
+
+            for (variant_idx, variant) in variants.iter().enumerate() {
+                let base = variant_idx * stride;
+                let alt1 = dense_sum_alt_no_missing(data, base, offsets1);
+                let alt2 = dense_sum_alt_no_missing(data, base, offsets2);
+
+                let pi1 = scale1.map(|(scale, inv_n_sq)| {
+                    if alt1 == 0 || alt1 == n1_total {
+                        0.0
+                    } else {
+                        let alt_f = alt1 as f64;
+                        let ref_f = (n1_total - alt1) as f64;
+                        scale * (1.0 - (ref_f * ref_f + alt_f * alt_f) * inv_n_sq)
+                    }
+                });
+                let pi2 = scale2.map(|(scale, inv_n_sq)| {
+                    if alt2 == 0 || alt2 == n2_total {
+                        0.0
+                    } else {
+                        let alt_f = alt2 as f64;
+                        let ref_f = (n2_total - alt2) as f64;
+                        scale * (1.0 - (ref_f * ref_f + alt_f * alt_f) * inv_n_sq)
+                    }
+                });
+
+                let dxy = dense_dxy_from_biallelic_counts(n1_total, alt1, n2_total, alt2);
+                let (fst, num_component, den_component) =
+                    dense_fst_components_from_biallelic(dxy, pi1, pi2);
+
+                sites.push(SiteFstHudson {
+                    position: ZeroBasedPosition(variant.position).to_one_based(),
+                    fst,
+                    d_xy: dxy,
+                    pi_pop1: pi1,
+                    pi_pop2: pi2,
+                    n1_called: n1_total,
+                    n2_called: n2_total,
+                    num_component,
+                    den_component,
+                });
+            }
+        }
+    }
+
+    sites
+}
+
 /// Aggregate per-site Hudson components into a window/regional FST using ratio of sums.
 ///
 /// Mathematical Foundation:
@@ -2096,14 +2895,7 @@ pub fn calculate_hudson_fst_per_site(
 /// Monomorphic Sites:
 /// Sites with D_xy = π = 0 contribute (0, 0) to the sums, which is mathematically correct.
 pub fn aggregate_hudson_from_sites(sites: &[SiteFstHudson]) -> Option<f64> {
-    let mut num_sum = 0.0_f64;
-    let mut den_sum = 0.0_f64;
-    for s in sites {
-        if let (Some(nc), Some(dc)) = (s.num_component, s.den_component) {
-            num_sum += nc;
-            den_sum += dc;
-        }
-    }
+    let (num_sum, den_sum) = hudson_component_sums(sites);
     if den_sum > FST_EPSILON {
         Some(num_sum / den_sum)
     } else if num_sum.abs() <= FST_EPSILON {
@@ -2250,45 +3042,66 @@ fn calculate_hudson_fst_for_pair_core<'a>(
         ));
     }
 
-    // Calculate per-site Hudson FST values
-    let site_values = if let Some(reg) = region {
-        calculate_hudson_fst_per_site(pop1_context, pop2_context, reg)
-    } else {
-        if pop1_context.variants.is_empty() {
-            Vec::new()
-        } else {
-            let pop1_mem =
-                HapMembership::build(pop1_context.sample_names.len(), &pop1_context.haplotypes);
-            let pop2_mem =
-                HapMembership::build(pop2_context.sample_names.len(), &pop2_context.haplotypes);
-            pop1_context
-                .variants
-                .iter()
-                .map(|variant| hudson_site_from_variant(variant, &pop1_mem, &pop2_mem))
-                .collect()
-        }
+    let summary_pair = match (
+        pop1_context.dense_summary.as_deref(),
+        pop2_context.dense_summary.as_deref(),
+    ) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
     };
 
-    // Compute regional FST using unbiased ratio-of-sums from per-site components
-    let regional_fst = aggregate_hudson_from_sites(&site_values);
+    let dense_shared = match (pop1_context.dense_genotypes, pop2_context.dense_genotypes) {
+        (Some(a), Some(b)) if std::ptr::eq(a, b) && a.ploidy() == 2 => Some(a),
+        _ => None,
+    };
+
+    let mut site_values = Vec::new();
+    let (num_sum, den_sum) = if let Some(reg) = region {
+        site_values = calculate_hudson_fst_per_site(pop1_context, pop2_context, reg);
+        hudson_component_sums(&site_values)
+    } else if let Some((summary1, summary2)) = summary_pair {
+        aggregate_hudson_components_from_summaries(summary1, summary2)
+    } else if let Some(matrix) = dense_shared {
+        if pop1_context.variants.is_empty() {
+            (0.0, 0.0)
+        } else {
+            let pop1_mem = DenseMembership::build(matrix, &pop1_context.haplotypes);
+            let pop2_mem = DenseMembership::build(matrix, &pop2_context.haplotypes);
+            site_values = dense_hudson_sites(matrix, pop1_context.variants, &pop1_mem, &pop2_mem);
+            hudson_component_sums(&site_values)
+        }
+    } else if pop1_context.variants.is_empty() {
+        (0.0, 0.0)
+    } else {
+        let pop1_mem =
+            HapMembership::build(pop1_context.sample_names.len(), &pop1_context.haplotypes);
+        let pop2_mem =
+            HapMembership::build(pop2_context.sample_names.len(), &pop2_context.haplotypes);
+        site_values = pop1_context
+            .variants
+            .iter()
+            .map(|variant| hudson_site_from_variant(variant, &pop1_mem, &pop2_mem))
+            .collect();
+        hudson_component_sums(&site_values)
+    };
+
+    let regional_fst = if den_sum > FST_EPSILON {
+        Some(num_sum / den_sum)
+    } else if num_sum.abs() <= FST_EPSILON {
+        Some(0.0)
+    } else {
+        None
+    };
 
     // Calculate auxiliary π and Dxy values for output (but don't use for FST)
-    let pi1_raw = calculate_pi(
-        pop1_context.variants,
-        &pop1_context.haplotypes,
-        pop1_context.sequence_length,
-    );
+    let pi1_raw = calculate_pi_for_population(pop1_context);
     let pi1_opt = if pi1_raw.is_finite() {
         Some(pi1_raw)
     } else {
         None
     };
 
-    let pi2_raw = calculate_pi(
-        pop2_context.variants,
-        &pop2_context.haplotypes,
-        pop2_context.sequence_length,
-    );
+    let pi2_raw = calculate_pi_for_population(pop2_context);
     let pi2_opt = if pi2_raw.is_finite() {
         Some(pi2_raw)
     } else {
@@ -2514,15 +3327,142 @@ pub fn calculate_inversion_allele_frequency(
 
 // Count the number of segregating sites, where a site has more than one allele
 pub fn count_segregating_sites(variants: &[Variant]) -> usize {
-    // Returns the count as usize
     variants
-        .par_iter() // Use parallel iteration for efficiency over the variants slice
-        .filter(|v| {
-            // Collect all alleles across all genotypes into a HashSet to find unique alleles
-            let alleles: HashSet<_> = v.genotypes.iter().flatten().flatten().collect();
-            alleles.len() > 1 // True if the site is segregating (has multiple alleles)
-        })
-        .count() // Count the number of segregating sites
+        .par_iter()
+        .filter(|variant| variant_is_segregating(variant))
+        .count()
+}
+
+fn variant_is_segregating(variant: &Variant) -> bool {
+    let mut first = None;
+    for genotype_opt in &variant.genotypes {
+        if let Some(genotype) = genotype_opt {
+            for &allele in genotype {
+                match first {
+                    None => first = Some(allele),
+                    Some(value) if value != allele => return true,
+                    _ => {}
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn count_segregating_sites_for_population(context: &PopulationContext<'_>) -> usize {
+    if let Some(summary) = context.dense_summary.as_deref() {
+        return count_segregating_sites_from_summary(summary);
+    }
+    if let Some(matrix) = context.dense_genotypes {
+        if matrix.ploidy() == 2 {
+            let membership = DenseMembership::build(matrix, &context.haplotypes);
+            if membership.len() <= 1 {
+                return 0;
+            }
+            return count_segregating_sites_dense(matrix, &membership);
+        }
+    }
+    count_segregating_sites(context.variants)
+}
+
+fn count_segregating_sites_dense(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+) -> usize {
+    if matrix.max_allele() <= 1 {
+        return count_segregating_sites_dense_biallelic(matrix, membership);
+    }
+
+    let offsets = membership.offsets();
+    if offsets.is_empty() {
+        return 0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut segregating = 0usize;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let mut first: Option<u8> = None;
+            let mut polymorphic = false;
+            for &offset in offsets {
+                let idx = base + offset;
+                if dense_missing(bits, idx) {
+                    continue;
+                }
+                let allele = data[idx];
+                if let Some(value) = first {
+                    if allele != value {
+                        polymorphic = true;
+                        break;
+                    }
+                } else {
+                    first = Some(allele);
+                }
+            }
+            if polymorphic {
+                segregating += 1;
+            }
+        }
+    } else {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let mut first: Option<u8> = None;
+            let mut polymorphic = false;
+            for &offset in offsets {
+                let idx = base + offset;
+                let allele = data[idx];
+                if let Some(value) = first {
+                    if allele != value {
+                        polymorphic = true;
+                        break;
+                    }
+                } else {
+                    first = Some(allele);
+                }
+            }
+            if polymorphic {
+                segregating += 1;
+            }
+        }
+    }
+
+    segregating
+}
+
+fn count_segregating_sites_dense_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+) -> usize {
+    let offsets = membership.offsets();
+    if offsets.len() < 2 {
+        return 0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let total = offsets.len();
+    let mut segregating = 0usize;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            if called >= 2 && alt > 0 && alt < called {
+                segregating += 1;
+            }
+        }
+    } else {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            if alt > 0 && alt < total {
+                segregating += 1;
+            }
+        }
+    }
+
+    segregating
 }
 
 // Calculate pairwise differences and comparable sites between all sample pairs
@@ -2803,6 +3743,125 @@ pub fn calculate_pi(
     );
 
     pi
+}
+
+fn calculate_pi_dense_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    seq_length: i64,
+) -> f64 {
+    let offsets = membership.offsets();
+    if offsets.len() <= 1 {
+        return 0.0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut sum_pi = 0.0_f64;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let (total_called, alt_count) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            if let Some(pi) = dense_pi_from_counts(total_called, alt_count) {
+                sum_pi += pi;
+            }
+        }
+    } else {
+        let total = offsets.len();
+        if total < 2 {
+            return 0.0;
+        }
+        let n = total as f64;
+        let scale = n / (n - 1.0);
+        let inv_n_sq = 1.0 / (n * n);
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            if alt == 0 || alt == total {
+                continue;
+            }
+            let alt_f = alt as f64;
+            let ref_f = (total - alt) as f64;
+            let sum_sq = ref_f * ref_f + alt_f * alt_f;
+            sum_pi += scale * (1.0 - sum_sq * inv_n_sq);
+        }
+    }
+
+    sum_pi / seq_length as f64
+}
+
+fn calculate_pi_dense(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    seq_length: i64,
+) -> f64 {
+    if membership.len() <= 1 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: insufficient haplotypes ({})",
+                membership.len()
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length < 0 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: invalid sequence length ({})",
+                seq_length
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length == 0 {
+        log(
+            LogLevel::Warning,
+            "Cannot calculate pi: zero sequence length causes division by zero",
+        );
+        return f64::INFINITY;
+    }
+
+    if matrix.max_allele() <= 1 {
+        return calculate_pi_dense_biallelic(matrix, membership, seq_length);
+    }
+
+    let mut counts = vec![0u32; 256];
+    let mut used = Vec::with_capacity(8);
+    let mut sum_pi = 0.0_f64;
+
+    for variant_idx in 0..matrix.variant_count() {
+        let (total_called, sum_counts_sq) =
+            dense_collect_counts(matrix, membership, variant_idx, &mut counts, &mut used);
+        if total_called >= 2 {
+            let n = total_called as f64;
+            let sum_p2 = sum_counts_sq / (n * n);
+            sum_pi += n / (n - 1.0) * (1.0 - sum_p2);
+        }
+        dense_reset_counts(&mut counts, &mut used);
+    }
+
+    sum_pi / seq_length as f64
+}
+
+pub fn calculate_pi_for_population(context: &PopulationContext<'_>) -> f64 {
+    if let Some(summary) = context.dense_summary.as_deref() {
+        return calculate_pi_from_summary(summary, context.sequence_length);
+    }
+    if let Some(matrix) = context.dense_genotypes {
+        if matrix.ploidy() == 2 {
+            let membership = DenseMembership::build(matrix, &context.haplotypes);
+            return calculate_pi_dense(matrix, &membership, context.sequence_length);
+        }
+    }
+    calculate_pi(
+        context.variants,
+        &context.haplotypes,
+        context.sequence_length,
+    )
 }
 
 /// Calculate per-site diversity metrics (π and Watterson's θ) across a genomic region.

--- a/src/tests/hudson_fst_tests.rs
+++ b/src/tests/hudson_fst_tests.rs
@@ -15,46 +15,74 @@ mod hudson_fst_tests {
     fn test_hudson_fst_per_site_calculation() {
         // Test case 1: Perfect population structure (FST should be 1.0)
         // Pop1: all 0|0, Pop2: all 1|1
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            Some(vec![0, 0]), // sample 1 - pop1  
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                Some(vec![0, 0]), // sample 1 - pop1
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right), 
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
-            id: PopulationId::HaplotypeGroup(1), 
+            id: PopulationId::HaplotypeGroup(1),
             haplotypes: pop2_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         // Test the Hudson FST calculation
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("Perfect structure FST: {:?}", outcome.fst);
-        
+
         // With perfect population structure, FST should be close to 1.0
         if let Some(fst) = outcome.fst {
-            assert!(fst > 0.8, "FST {} is too low for perfect population structure", fst);
+            assert!(
+                fst > 0.8,
+                "FST {} is too low for perfect population structure",
+                fst
+            );
             assert!(fst <= 1.0, "FST {} exceeds maximum value of 1.0", fst);
         } else {
             panic!("FST calculation returned None for perfect population structure");
@@ -65,26 +93,44 @@ mod hudson_fst_tests {
     fn test_hudson_fst_no_structure() {
         // Test case 2: No population structure (FST should be ~0)
         // Both populations have same allele frequencies
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 1]), // sample 0 - pop1 (heterozygous)
-            Some(vec![1, 0]), // sample 1 - pop1 (heterozygous)
-            Some(vec![0, 1]), // sample 2 - pop2 (heterozygous) 
-            Some(vec![1, 0]), // sample 3 - pop2 (heterozygous)
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 1]), // sample 0 - pop1 (heterozygous)
+                Some(vec![1, 0]), // sample 1 - pop1 (heterozygous)
+                Some(vec![0, 1]), // sample 2 - pop2 (heterozygous)
+                Some(vec![1, 0]), // sample 3 - pop2 (heterozygous)
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -93,49 +139,80 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("No structure FST: {:?}", outcome.fst);
-        
+
         // With no population structure, FST can be negative (which is expected)
         // The negative value indicates that within-population diversity is higher than between-population diversity
         if let Some(fst) = outcome.fst {
-            assert!(fst >= -1.0 && fst <= 1.0, "FST {} is outside valid range [-1, 1]", fst);
+            assert!(
+                fst >= -1.0 && fst <= 1.0,
+                "FST {} is outside valid range [-1, 1]",
+                fst
+            );
             // For this specific case with identical allele frequencies but different arrangements,
             // negative FST is mathematically correct
-            println!("FST = {} is within expected range for this data pattern", fst);
+            println!(
+                "FST = {} is within expected range for this data pattern",
+                fst
+            );
         } else {
             panic!("FST calculation returned None for valid data");
         }
     }
 
-    #[test] 
+    #[test]
     fn test_hudson_fst_per_site_components() {
         // Test that per-site components are correctly calculated
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            Some(vec![0, 0]), // sample 1 - pop1
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                Some(vec![0, 0]), // sample 1 - pop1
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -144,46 +221,73 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
-        let region = QueryRegion { start: 99, end: 101 }; // 0-based, so 99-101 covers position 100
+        let region = QueryRegion {
+            start: 99,
+            end: 101,
+        }; // 0-based, so 99-101 covers position 100
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_ok(), "Hudson FST with sites calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST with sites calculation failed: {:?}",
+            result.err()
+        );
 
         let (outcome, sites) = result.unwrap();
-        
+
         println!("Number of sites returned: {}", sites.len());
         for (i, site) in sites.iter().enumerate() {
-            println!("Site {}: pos={}, fst={:?}, dxy={:?}", i, site.position, site.fst, site.d_xy);
+            println!(
+                "Site {}: pos={}, fst={:?}, dxy={:?}",
+                i, site.position, site.fst, site.d_xy
+            );
         }
-        
+
         // Find the site at position 101 (where the actual data is)
         let site_101 = sites.iter().find(|s| s.position == 101);
         assert!(site_101.is_some(), "Site at position 101 not found");
-        
+
         let site = site_101.unwrap();
         println!("Site 101 FST: {:?}", site.fst);
         println!("Site 101 D_xy: {:?}", site.d_xy);
         println!("Site 101 pi_pop1: {:?}", site.pi_pop1);
         println!("Site 101 pi_pop2: {:?}", site.pi_pop2);
-        
+
         // With perfect structure: D_xy should be 1.0, pi should be 0.0
         assert!(site.d_xy.is_some(), "D_xy should be calculated");
         assert!(site.pi_pop1.is_some(), "pi_pop1 should be calculated");
         assert!(site.pi_pop2.is_some(), "pi_pop2 should be calculated");
-        
+
         if let (Some(dxy), Some(pi1), Some(pi2)) = (site.d_xy, site.pi_pop1, site.pi_pop2) {
-            assert!((dxy - 1.0).abs() < 0.01, "D_xy should be ~1.0 for perfect structure, got {}", dxy);
-            assert!(pi1.abs() < 0.01, "pi_pop1 should be ~0.0 for monomorphic population, got {}", pi1);
-            assert!(pi2.abs() < 0.01, "pi_pop2 should be ~0.0 for monomorphic population, got {}", pi2);
+            assert!(
+                (dxy - 1.0).abs() < 0.01,
+                "D_xy should be ~1.0 for perfect structure, got {}",
+                dxy
+            );
+            assert!(
+                pi1.abs() < 0.01,
+                "pi_pop1 should be ~0.0 for monomorphic population, got {}",
+                pi1
+            );
+            assert!(
+                pi2.abs() < 0.01,
+                "pi_pop2 should be ~0.0 for monomorphic population, got {}",
+                pi2
+            );
         }
-        
+
         // Regional FST should match per-site aggregation
         if let Some(regional_fst) = outcome.fst {
             if let Some(site_fst) = site.fst {
-                assert!((regional_fst - site_fst).abs() < 0.01, 
-                    "Regional FST {} should match site FST {} for single-site region", 
-                    regional_fst, site_fst);
+                assert!(
+                    (regional_fst - site_fst).abs() < 0.01,
+                    "Regional FST {} should match site FST {} for single-site region",
+                    regional_fst,
+                    site_fst
+                );
             }
         }
     }
@@ -206,7 +310,12 @@ mod hudson_fst_tests {
 
         // No variants - monomorphic region
         let variants = vec![];
-        let sample_names = vec!["sample1".to_string(), "sample2".to_string(), "sample3".to_string(), "sample4".to_string()];
+        let sample_names = vec![
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
+            "sample4".to_string(),
+        ];
 
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
@@ -214,6 +323,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -222,60 +333,87 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation should succeed for monomorphic window");
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation should succeed for monomorphic window"
+        );
 
         let outcome = result.unwrap();
         println!("Monomorphic window FST: {:?}", outcome.fst);
 
         // Monomorphic windows should return FST = 0.0, not None
-        assert!(outcome.fst.is_some(), "Monomorphic window should have FST = 0.0, not None");
-        assert_eq!(outcome.fst.unwrap(), 0.0, "Monomorphic window FST should be exactly 0.0");
+        assert!(
+            outcome.fst.is_some(),
+            "Monomorphic window should have FST = 0.0, not None"
+        );
+        assert_eq!(
+            outcome.fst.unwrap(),
+            0.0,
+            "Monomorphic window FST should be exactly 0.0"
+        );
     }
 
     #[test]
     fn test_hudson_fst_ratio_of_sums_no_missingness() {
         // Test 1: Ratio-of-sums with no missingness (two sites, mixed structure)
         // Expected regional FST = 5/9 ≈ 0.5555555556
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): perfect structure
         // sample0: [0,0], sample1: [0,0], sample2: [1,1], sample3: [1,1]
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 0]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 0]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         // Site B (pos=200): identical pop frequencies (each pop has 2×0 and 2×1)
         // sample0: [0,1], sample1: [0,1], sample2: [0,1], sample3: [0,1]
-        let variant_b = create_test_variant(200, vec![
-            Some(vec![0, 1]), // sample0
-            Some(vec![0, 1]), // sample1
-            Some(vec![0, 1]), // sample2
-            Some(vec![0, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                Some(vec![0, 1]), // sample0
+                Some(vec![0, 1]), // sample1
+                Some(vec![0, 1]), // sample2
+                Some(vec![0, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         // pop1 = samples {0,1}, pop2 = samples {2,3}
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -284,6 +422,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -292,85 +432,140 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data (non-None FST)
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Site A (position 101 in 1-based): perfect structure
-        let site_a = variant_sites.iter().find(|s| s.position == 101).expect("Site A not found");
-        assert!((site_a.fst.unwrap() - 1.0).abs() < 1e-12, "Site A FST should be exactly 1.0");
-        assert!((site_a.num_component.unwrap() - 1.0).abs() < 1e-12, "Site A numerator should be 1.0");
-        assert!((site_a.den_component.unwrap() - 1.0).abs() < 1e-12, "Site A denominator should be 1.0");
+        let site_a = variant_sites
+            .iter()
+            .find(|s| s.position == 101)
+            .expect("Site A not found");
+        assert!(
+            (site_a.fst.unwrap() - 1.0).abs() < 1e-12,
+            "Site A FST should be exactly 1.0"
+        );
+        assert!(
+            (site_a.num_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A numerator should be 1.0"
+        );
+        assert!(
+            (site_a.den_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A denominator should be 1.0"
+        );
 
         // Site B (position 201 in 1-based): FST = -1/3
-        let site_b = variant_sites.iter().find(|s| s.position == 201).expect("Site B not found");
-        assert!((site_b.fst.unwrap() - (-1.0/3.0)).abs() < 1e-12, "Site B FST should be exactly -1/3");
-        assert!((site_b.num_component.unwrap() - (-1.0/6.0)).abs() < 1e-12, "Site B numerator should be -1/6");
-        assert!((site_b.den_component.unwrap() - 0.5).abs() < 1e-12, "Site B denominator should be 0.5");
+        let site_b = variant_sites
+            .iter()
+            .find(|s| s.position == 201)
+            .expect("Site B not found");
+        assert!(
+            (site_b.fst.unwrap() - (-1.0 / 3.0)).abs() < 1e-12,
+            "Site B FST should be exactly -1/3"
+        );
+        assert!(
+            (site_b.num_component.unwrap() - (-1.0 / 6.0)).abs() < 1e-12,
+            "Site B numerator should be -1/6"
+        );
+        assert!(
+            (site_b.den_component.unwrap() - 0.5).abs() < 1e-12,
+            "Site B denominator should be 0.5"
+        );
 
         // Regional FST from ratio-of-sums: (5/6) / (3/2) = 5/9
         let expected_regional_fst = 5.0 / 9.0;
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
-        assert!((aggregated_fst - expected_regional_fst).abs() < 1e-12, 
-            "Aggregated FST should be exactly 5/9, got {}", aggregated_fst);
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
+        assert!(
+            (aggregated_fst - expected_regional_fst).abs() < 1e-12,
+            "Aggregated FST should be exactly 5/9, got {}",
+            aggregated_fst
+        );
 
         // Window FST should match (if using unbiased implementation)
         assert!(outcome.fst.is_some(), "Window FST should be Some");
-        assert!((outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
-            "Window FST should match ratio-of-sums: expected {}, got {}", 
-            expected_regional_fst, outcome.fst.unwrap());
+        assert!(
+            (outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
+            "Window FST should match ratio-of-sums: expected {}, got {}",
+            expected_regional_fst,
+            outcome.fst.unwrap()
+        );
 
-        println!("Test 1 PASSED: Regional FST = {} (expected 5/9 = {})", 
-            outcome.fst.unwrap(), expected_regional_fst);
+        println!(
+            "Test 1 PASSED: Regional FST = {} (expected 5/9 = {})",
+            outcome.fst.unwrap(),
+            expected_regional_fst
+        );
     }
 
     #[test]
     fn test_hudson_fst_ratio_of_sums_uneven_missingness() {
         // Test 2: Ratio-of-sums under uneven missingness
         // Expected regional FST = 1/3 ≈ 0.3333333333
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): perfect structure (same as Test 1)
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 0]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 0]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         // Site B (pos=200): missing data for samples 0 and 2
         // sample0: None, sample1: [0,1], sample2: None, sample3: [0,1]
         // This gives each pop n=2 with {0:1, 1:1}
-        let variant_b = create_test_variant(200, vec![
-            None,           // sample0 - missing
-            Some(vec![0, 1]), // sample1
-            None,           // sample2 - missing  
-            Some(vec![0, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                None,             // sample0 - missing
+                Some(vec![0, 1]), // sample1
+                None,             // sample2 - missing
+                Some(vec![0, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -379,6 +574,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -387,67 +584,116 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data (non-None FST)
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Site A unchanged (FST=1, num=1, den=1)
-        let site_a = variant_sites.iter().find(|s| s.position == 101).expect("Site A not found");
-        assert!((site_a.fst.unwrap() - 1.0).abs() < 1e-12, "Site A FST should be exactly 1.0");
-        assert!((site_a.num_component.unwrap() - 1.0).abs() < 1e-12, "Site A numerator should be 1.0");
-        assert!((site_a.den_component.unwrap() - 1.0).abs() < 1e-12, "Site A denominator should be 1.0");
+        let site_a = variant_sites
+            .iter()
+            .find(|s| s.position == 101)
+            .expect("Site A not found");
+        assert!(
+            (site_a.fst.unwrap() - 1.0).abs() < 1e-12,
+            "Site A FST should be exactly 1.0"
+        );
+        assert!(
+            (site_a.num_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A numerator should be 1.0"
+        );
+        assert!(
+            (site_a.den_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A denominator should be 1.0"
+        );
 
         // Site B with missingness: FST = -1, num = -0.5, den = 0.5
-        let site_b = variant_sites.iter().find(|s| s.position == 201).expect("Site B not found");
-        assert!((site_b.fst.unwrap() - (-1.0)).abs() < 1e-12, "Site B FST should be exactly -1.0");
-        assert!((site_b.num_component.unwrap() - (-0.5)).abs() < 1e-12, "Site B numerator should be -0.5");
-        assert!((site_b.den_component.unwrap() - 0.5).abs() < 1e-12, "Site B denominator should be 0.5");
+        let site_b = variant_sites
+            .iter()
+            .find(|s| s.position == 201)
+            .expect("Site B not found");
+        assert!(
+            (site_b.fst.unwrap() - (-1.0)).abs() < 1e-12,
+            "Site B FST should be exactly -1.0"
+        );
+        assert!(
+            (site_b.num_component.unwrap() - (-0.5)).abs() < 1e-12,
+            "Site B numerator should be -0.5"
+        );
+        assert!(
+            (site_b.den_component.unwrap() - 0.5).abs() < 1e-12,
+            "Site B denominator should be 0.5"
+        );
 
         // Regional FST: (1 + (-0.5)) / (1 + 0.5) = 0.5 / 1.5 = 1/3
         let expected_regional_fst = 1.0 / 3.0;
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
-        assert!((aggregated_fst - expected_regional_fst).abs() < 1e-12, 
-            "Aggregated FST should be exactly 1/3, got {}", aggregated_fst);
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
+        assert!(
+            (aggregated_fst - expected_regional_fst).abs() < 1e-12,
+            "Aggregated FST should be exactly 1/3, got {}",
+            aggregated_fst
+        );
 
         // Window FST should match
         assert!(outcome.fst.is_some(), "Window FST should be Some");
-        assert!((outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
-            "Window FST should match ratio-of-sums: expected {}, got {}", 
-            expected_regional_fst, outcome.fst.unwrap());
+        assert!(
+            (outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
+            "Window FST should match ratio-of-sums: expected {}, got {}",
+            expected_regional_fst,
+            outcome.fst.unwrap()
+        );
 
-        println!("Test 2 PASSED: Regional FST = {} (expected 1/3 = {})", 
-            outcome.fst.unwrap(), expected_regional_fst);
+        println!(
+            "Test 2 PASSED: Regional FST = {} (expected 1/3 = {})",
+            outcome.fst.unwrap(),
+            expected_regional_fst
+        );
     }
 
     #[test]
     fn test_hudson_fst_monomorphic_window_surgical() {
         // Test 3: Monomorphic window ⇒ overall Hudson FST = 0
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // No variants at all
         let variants = vec![];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 102 };
+        let region = QueryRegion {
+            start: 100,
+            end: 102,
+        };
         let sequence_length = (region.end - region.start + 1) as i64; // 3
 
         let pop1_context = PopulationContext {
@@ -456,6 +702,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -464,72 +712,111 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Should have 3 sites (positions 100, 101, 102), all with no data
         assert_eq!(sites.len(), 3, "Should have exactly 3 sites in region");
 
         // Each site should have None for all components
         for site in &sites {
-            assert!(site.fst.is_none(), "Site {} FST should be None", site.position);
-            assert!(site.num_component.is_none(), "Site {} num_component should be None", site.position);
-            assert!(site.den_component.is_none(), "Site {} den_component should be None", site.position);
+            assert!(
+                site.fst.is_none(),
+                "Site {} FST should be None",
+                site.position
+            );
+            assert!(
+                site.num_component.is_none(),
+                "Site {} num_component should be None",
+                site.position
+            );
+            assert!(
+                site.den_component.is_none(),
+                "Site {} den_component should be None",
+                site.position
+            );
         }
 
         // Aggregated FST should be 0.0 (Σnum = 0, Σden = 0)
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some(0.0)");
-        assert!((aggregated_fst - 0.0).abs() < 1e-12, "Aggregated FST should be exactly 0.0");
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some(0.0)");
+        assert!(
+            (aggregated_fst - 0.0).abs() < 1e-12,
+            "Aggregated FST should be exactly 0.0"
+        );
 
         // Window FST should also be 0.0
         assert!(outcome.fst.is_some(), "Window FST should be Some(0.0)");
-        assert!((outcome.fst.unwrap() - 0.0).abs() < 1e-12, "Window FST should be exactly 0.0");
+        assert!(
+            (outcome.fst.unwrap() - 0.0).abs() < 1e-12,
+            "Window FST should be exactly 0.0"
+        );
 
-        println!("Test 3 PASSED: Monomorphic window FST = {} (expected 0.0)", outcome.fst.unwrap());
+        println!(
+            "Test 3 PASSED: Monomorphic window FST = {} (expected 0.0)",
+            outcome.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_pi_dxy_consistency_with_uneven_coverage() {
         // Test that π/Dxy calculations are consistent with per-site math
         // when pairs have different numbers of comparable sites
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): all samples have data
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 1]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 0]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 1]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 0]), // sample3
+            ],
+        );
 
         // Site B (pos=200): only samples 1 and 3 have data (uneven coverage)
-        let variant_b = create_test_variant(200, vec![
-            None,             // sample0 - missing
-            Some(vec![0, 0]), // sample1
-            None,             // sample2 - missing
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                None,             // sample0 - missing
+                Some(vec![0, 0]), // sample1
+                None,             // sample2 - missing
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -538,6 +825,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -546,29 +835,29 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        
+
         // Should have 2 variant sites but with different coverage patterns
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Verify that π and Dxy values are consistent with per-site aggregation
-        let manual_pi1_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.pi_pop1)
-            .sum();
-        let manual_pi2_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.pi_pop2)
-            .sum();
-        let manual_dxy_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.d_xy)
-            .sum();
+        let manual_pi1_sum: f64 = variant_sites.iter().filter_map(|s| s.pi_pop1).sum();
+        let manual_pi2_sum: f64 = variant_sites.iter().filter_map(|s| s.pi_pop2).sum();
+        let manual_dxy_sum: f64 = variant_sites.iter().filter_map(|s| s.d_xy).sum();
 
         let expected_pi1 = manual_pi1_sum / sequence_length as f64;
         let expected_pi2 = manual_pi2_sum / sequence_length as f64;
@@ -576,21 +865,30 @@ mod hudson_fst_tests {
 
         // The reported π/Dxy should match per-site aggregation
         if let Some(reported_pi1) = outcome.pi_pop1 {
-            assert!((reported_pi1 - expected_pi1).abs() < 1e-12, 
-                "Reported π1 ({}) should match per-site aggregation ({})", 
-                reported_pi1, expected_pi1);
+            assert!(
+                (reported_pi1 - expected_pi1).abs() < 1e-12,
+                "Reported π1 ({}) should match per-site aggregation ({})",
+                reported_pi1,
+                expected_pi1
+            );
         }
 
         if let Some(reported_pi2) = outcome.pi_pop2 {
-            assert!((reported_pi2 - expected_pi2).abs() < 1e-12, 
-                "Reported π2 ({}) should match per-site aggregation ({})", 
-                reported_pi2, expected_pi2);
+            assert!(
+                (reported_pi2 - expected_pi2).abs() < 1e-12,
+                "Reported π2 ({}) should match per-site aggregation ({})",
+                reported_pi2,
+                expected_pi2
+            );
         }
 
         if let Some(reported_dxy) = outcome.d_xy {
-            assert!((reported_dxy - expected_dxy).abs() < 1e-12, 
-                "Reported Dxy ({}) should match per-site aggregation ({})", 
-                reported_dxy, expected_dxy);
+            assert!(
+                (reported_dxy - expected_dxy).abs() < 1e-12,
+                "Reported Dxy ({}) should match per-site aggregation ({})",
+                reported_dxy,
+                expected_dxy
+            );
         }
 
         println!("π/Dxy consistency test PASSED: per-site aggregation matches reported values");
@@ -600,34 +898,46 @@ mod hudson_fst_tests {
     fn test_hudson_fst_multi_allelic_site() {
         // Test multi-allelic site: 3 alleles with different frequencies between populations
         // pop1: A/C/G at 0.5/0.25/0.25 vs pop2: A/C/G at 0.2/0.3/0.5
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Multi-allelic site with alleles 0=A, 1=C, 2=G
         // pop1: 2×A, 1×C, 1×G → frequencies: A=0.5, C=0.25, G=0.25
         // pop2: 1×A, 1×C, 2×G → frequencies: A=0.25, C=0.25, G=0.5
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0: A/A (pop1)
-            Some(vec![1, 2]), // sample1: C/G (pop1)
-            Some(vec![0, 1]), // sample2: A/C (pop2)
-            Some(vec![2, 2]), // sample3: G/G (pop2)
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0: A/A (pop1)
+                Some(vec![1, 2]), // sample1: C/G (pop1)
+                Some(vec![0, 1]), // sample2: A/C (pop2)
+                Some(vec![2, 2]), // sample3: G/G (pop2)
+            ],
+        );
 
         let variants = vec![variant];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 100 };
+        let region = QueryRegion {
+            start: 100,
+            end: 100,
+        };
         let sequence_length = 1;
 
         let pop1_context = PopulationContext {
@@ -636,6 +946,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -644,80 +956,118 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_ok(), "Hudson FST calculation should succeed for multi-allelic site");
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation should succeed for multi-allelic site"
+        );
 
         let (_outcome, sites) = result.unwrap();
-        
+
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
         assert_eq!(variant_sites.len(), 1, "Should have exactly 1 variant site");
 
         let site = variant_sites[0];
-        
+
         // Manual calculation for verification:
         // pop1 frequencies: p1A=0.5, p1C=0.25, p1G=0.25
         // pop2 frequencies: p2A=0.25, p2C=0.25, p2G=0.5
         // Dxy = 1 - (p1A*p2A + p1C*p2C + p1G*p2G) = 1 - (0.5*0.25 + 0.25*0.25 + 0.25*0.5) = 1 - 0.3125 = 0.6875
         let expected_dxy = 0.6875;
-        
+
         // π1 = (4/3) * (1 - (0.5² + 0.25² + 0.25²)) = (4/3) * (1 - 0.375) = (4/3) * 0.625 = 0.8333...
-        let expected_pi1 = (4.0/3.0) * (1.0 - (0.5*0.5 + 0.25*0.25 + 0.25*0.25));
-        
+        let expected_pi1 = (4.0 / 3.0) * (1.0 - (0.5 * 0.5 + 0.25 * 0.25 + 0.25 * 0.25));
+
         // π2 = (4/3) * (1 - (0.25² + 0.25² + 0.5²)) = (4/3) * (1 - 0.375) = (4/3) * 0.625 = 0.8333...
-        let expected_pi2 = (4.0/3.0) * (1.0 - (0.25*0.25 + 0.25*0.25 + 0.5*0.5));
-        
+        let expected_pi2 = (4.0 / 3.0) * (1.0 - (0.25 * 0.25 + 0.25 * 0.25 + 0.5 * 0.5));
+
         // numerator = Dxy - 0.5*(π1 + π2)
         let expected_numerator = expected_dxy - 0.5 * (expected_pi1 + expected_pi2);
         let expected_fst = expected_numerator / expected_dxy;
 
-        assert!((site.d_xy.unwrap() - expected_dxy).abs() < 1e-12, 
-            "Multi-allelic Dxy should be {}, got {}", expected_dxy, site.d_xy.unwrap());
-        
-        assert!((site.pi_pop1.unwrap() - expected_pi1).abs() < 1e-12,
-            "Multi-allelic π1 should be {}, got {}", expected_pi1, site.pi_pop1.unwrap());
-            
-        assert!((site.pi_pop2.unwrap() - expected_pi2).abs() < 1e-12,
-            "Multi-allelic π2 should be {}, got {}", expected_pi2, site.pi_pop2.unwrap());
+        assert!(
+            (site.d_xy.unwrap() - expected_dxy).abs() < 1e-12,
+            "Multi-allelic Dxy should be {}, got {}",
+            expected_dxy,
+            site.d_xy.unwrap()
+        );
 
-        assert!((site.fst.unwrap() - expected_fst).abs() < 1e-12,
-            "Multi-allelic FST should be {}, got {}", expected_fst, site.fst.unwrap());
+        assert!(
+            (site.pi_pop1.unwrap() - expected_pi1).abs() < 1e-12,
+            "Multi-allelic π1 should be {}, got {}",
+            expected_pi1,
+            site.pi_pop1.unwrap()
+        );
 
-        println!("Multi-allelic test PASSED: Dxy={:.6}, π1={:.6}, π2={:.6}, FST={:.6}", 
-            site.d_xy.unwrap(), site.pi_pop1.unwrap(), site.pi_pop2.unwrap(), site.fst.unwrap());
+        assert!(
+            (site.pi_pop2.unwrap() - expected_pi2).abs() < 1e-12,
+            "Multi-allelic π2 should be {}, got {}",
+            expected_pi2,
+            site.pi_pop2.unwrap()
+        );
+
+        assert!(
+            (site.fst.unwrap() - expected_fst).abs() < 1e-12,
+            "Multi-allelic FST should be {}, got {}",
+            expected_fst,
+            site.fst.unwrap()
+        );
+
+        println!(
+            "Multi-allelic test PASSED: Dxy={:.6}, π1={:.6}, π2={:.6}, FST={:.6}",
+            site.d_xy.unwrap(),
+            site.pi_pop1.unwrap(),
+            site.pi_pop2.unwrap(),
+            site.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_hudson_fst_identical_frequencies() {
         // Test case: identical allele frequencies between populations
         // This should give FST close to 0 (but may be slightly negative due to sampling)
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Both populations have identical frequencies: 50% A, 50% T
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 1]), // sample0: A/T (pop1)
-            Some(vec![1, 0]), // sample1: T/A (pop1) → pop1: 50% A, 50% T
-            Some(vec![0, 1]), // sample2: A/T (pop2)  
-            Some(vec![1, 0]), // sample3: T/A (pop2) → pop2: 50% A, 50% T
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 1]), // sample0: A/T (pop1)
+                Some(vec![1, 0]), // sample1: T/A (pop1) → pop1: 50% A, 50% T
+                Some(vec![0, 1]), // sample2: A/T (pop2)
+                Some(vec![1, 0]), // sample3: T/A (pop2) → pop2: 50% A, 50% T
+            ],
+        );
 
         let variants = vec![variant];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 100 };
+        let region = QueryRegion {
+            start: 100,
+            end: 100,
+        };
         let sequence_length = 1;
 
         let pop1_context = PopulationContext {
@@ -726,6 +1076,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -734,57 +1086,90 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (_outcome, sites) = result.unwrap();
-        
+
         assert_eq!(sites.len(), 1, "Should have exactly 1 site");
         let site = &sites[0];
-        
+
         assert!(site.d_xy.is_some(), "Dxy should be calculable");
-        assert!(site.pi_pop1.is_some(), "π1 should be calculable");  
+        assert!(site.pi_pop1.is_some(), "π1 should be calculable");
         assert!(site.pi_pop2.is_some(), "π2 should be calculable");
-        assert!(site.fst.is_some(), "FST should be calculable for identical frequencies");
-        
+        assert!(
+            site.fst.is_some(),
+            "FST should be calculable for identical frequencies"
+        );
+
         // With identical frequencies, FST can be negative due to finite sample corrections
         // The key is that it should be calculable (not None) and within reasonable bounds
-        assert!(site.fst.unwrap() >= -1.0 && site.fst.unwrap() <= 1.0, 
-            "FST should be within [-1,1] bounds, got {}", site.fst.unwrap());
+        assert!(
+            site.fst.unwrap() >= -1.0 && site.fst.unwrap() <= 1.0,
+            "FST should be within [-1,1] bounds, got {}",
+            site.fst.unwrap()
+        );
 
-        println!("Identical frequencies test PASSED: FST = {} (within bounds)", site.fst.unwrap());
+        println!(
+            "Identical frequencies test PASSED: FST = {} (within bounds)",
+            site.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_hudson_fst_variant_compatibility_guard() {
         // Test that calculate_hudson_fst_per_site guards against variant incompatibility
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Different variants for each population (incompatible)
-        let variants1 = vec![create_test_variant(100, vec![
-            Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), Some(vec![1, 0])
-        ])];
-        
-        let variants2 = vec![create_test_variant(200, vec![ // Different position!
-            Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), Some(vec![1, 0])
-        ])];
+        let variants1 = vec![create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]),
+                Some(vec![0, 1]),
+                Some(vec![1, 1]),
+                Some(vec![1, 0]),
+            ],
+        )];
+
+        let variants2 = vec![create_test_variant(
+            200,
+            vec![
+                // Different position!
+                Some(vec![0, 0]),
+                Some(vec![0, 1]),
+                Some(vec![1, 1]),
+                Some(vec![1, 0]),
+            ],
+        )];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
 
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
@@ -792,6 +1177,8 @@ mod hudson_fst_tests {
             variants: &variants1, // Different variants!
             sample_names: &sample_names,
             sequence_length: 2,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -800,15 +1187,23 @@ mod hudson_fst_tests {
             variants: &variants2, // Different variants!
             sample_names: &sample_names,
             sequence_length: 2,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         // Direct call to per-site function should return empty vector due to guard
         let sites = calculate_hudson_fst_per_site(&pop1_context, &pop2_context, region);
-        assert!(sites.is_empty(), "Should return empty vector for incompatible variants");
+        assert!(
+            sites.is_empty(),
+            "Should return empty vector for incompatible variants"
+        );
 
         // Safe wrapper should return error
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_err(), "Safe wrapper should return error for incompatible variants");
+        assert!(
+            result.is_err(),
+            "Safe wrapper should return error for incompatible variants"
+        );
 
         println!("Variant compatibility guard test PASSED");
     }
@@ -816,26 +1211,44 @@ mod hudson_fst_tests {
     #[test]
     fn test_hudson_fst_missing_data() {
         // Test Hudson FST with missing genotypes
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            None,             // sample 1 - pop1 (missing)
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                None,             // sample 1 - pop1 (missing)
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -844,21 +1257,34 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation with missing data failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation with missing data failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("Missing data FST: {:?}", outcome.fst);
-        
+
         // Should still calculate FST using available data
-        assert!(outcome.fst.is_some(), "FST should be calculated despite missing data");
-        
+        assert!(
+            outcome.fst.is_some(),
+            "FST should be calculated despite missing data"
+        );
+
         if let Some(fst) = outcome.fst {
-            // With remaining data (pop1: 2 haplotypes all 0, pop2: 4 haplotypes all 1), 
+            // With remaining data (pop1: 2 haplotypes all 0, pop2: 4 haplotypes all 1),
             // should still show strong structure
-            assert!(fst > 0.5, "FST {} should be high with remaining structured data", fst);
+            assert!(
+                fst > 0.5,
+                "FST {} should be high with remaining structured data",
+                fst
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache dense genotype matrices when constructing `Population` objects so PyO3 callers reuse NumPy-backed data across statistics invocations
- extend the stats module with dense membership/summary helpers and fast paths for π, segregating sites, Dxy, and Hudson FST that avoid rebuilding `Variant` state
- update manual `PopulationContext` initialisations and regenerate the Python benchmark JSON showing the new ferromic speedups

## Testing
- cargo check
- cargo test
- pytest src/pybenches/test_population_statistics_benchmarks.py --benchmark-json=bench.json


------
https://chatgpt.com/codex/tasks/task_e_68cdb702ca54832ea0e899c2f075b56d