### PR TITLE
Optimize Hudson FST summaries and update benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.18", features = ["extension-module"] }
+numpy = "0.18"
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.45", features = ["full"] }
 flate2 = "1.1" 

--- a/bench.json
+++ b/bench.json
@@ -1,0 +1,2492 @@
+{
+    "machine_info": {
+        "node": "5938fd4a60a3",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC 13.3.0",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.12.10",
+        "python_version": "3.12.10",
+        "python_build": [
+            "main",
+            "Aug 28 2025 21:54:05"
+        ],
+        "release": "6.12.13",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.12.10.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 5,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "GenuineIntel",
+            "brand_raw": "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz",
+            "hz_advertised_friendly": "2.6000 GHz",
+            "hz_actual_friendly": "2.5939 GHz",
+            "hz_advertised": [
+                2600000000,
+                0
+            ],
+            "hz_actual": [
+                2593906000,
+                0
+            ],
+            "stepping": 7,
+            "model": 85,
+            "family": 6,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arat",
+                "arch_capabilities",
+                "avx",
+                "avx2",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512vl",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "cmov",
+                "constant_tsc",
+                "cpuid",
+                "cpuid_fault",
+                "cx16",
+                "cx8",
+                "de",
+                "erms",
+                "f16c",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fxsr",
+                "hle",
+                "ht",
+                "hypervisor",
+                "invpcid",
+                "lahf_lm",
+                "lm",
+                "mca",
+                "mce",
+                "md_clear",
+                "mmx",
+                "movbe",
+                "msr",
+                "mtrr",
+                "nopl",
+                "nx",
+                "osxsave",
+                "pae",
+                "pat",
+                "pcid",
+                "pclmulqdq",
+                "pdpe1gb",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "rtm",
+                "sep",
+                "smap",
+                "smep",
+                "ss",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "syscall",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_known_freq",
+                "tscdeadline",
+                "umip",
+                "vme",
+                "vmx",
+                "x2apic",
+                "xsave",
+                "xsavec",
+                "xsaveopt",
+                "xsaves",
+                "xtopology"
+            ],
+            "l3_cache_size": 37486592,
+            "l2_cache_size": 3145728,
+            "l1_data_cache_size": 98304,
+            "l1_instruction_cache_size": 98304,
+            "l2_cache_line_size": 256,
+            "l2_cache_associativity": 6
+        }
+    },
+    "commit_info": {
+        "id": "179fe65e514faa70e84e81cdf02082d124a7c621",
+        "time": "2025-09-20T01:54:51+00:00",
+        "author_time": "2025-09-20T01:54:51+00:00",
+        "dirty": true,
+        "project": "ferromic",
+        "branch": "work"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_segregating_sites": 0.06171627224295964
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.3409999155555852e-06,
+                "max": 9.177000038107508e-06,
+                "mean": 3.1676000162406124e-06,
+                "stddev": 3.3828964470345473e-06,
+                "rounds": 5,
+                "median": 1.5240000266203424e-06,
+                "iqr": 2.6309999157092534e-06,
+                "q1": 1.4227500741981203e-06,
+                "q3": 4.053749989907374e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.3409999155555852e-06,
+                "hd15iqr": 9.177000038107508e-06,
+                "ops": 315696.4246978459,
+                "total": 1.5838000081203063e-05,
+                "data": [
+                    9.177000038107508e-06,
+                    2.3459999738406623e-06,
+                    1.5240000266203424e-06,
+                    1.3409999155555852e-06,
+                    1.4500001270789653e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.0925000171700958e-05,
+                "max": 0.00016395299985560996,
+                "mean": 5.132520000188379e-05,
+                "stddev": 6.301571629245592e-05,
+                "rounds": 5,
+                "median": 2.2894000039741513e-05,
+                "iqr": 4.042500000878135e-05,
+                "q1": 2.1217499977410625e-05,
+                "q3": 6.164249998619198e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.0925000171700958e-05,
+                "hd15iqr": 0.00016395299985560996,
+                "ops": 19483.606492781266,
+                "total": 0.00025662600000941893,
+                "data": [
+                    0.00016395299985560996,
+                    2.7539000029719318e-05,
+                    2.2894000039741513e-05,
+                    2.131499991264718e-05,
+                    2.0925000171700958e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_nucleotide_diversity": 0.023881682377483768
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.6560001060715877e-06,
+                "max": 9.748999900693889e-06,
+                "mean": 5.057399994257139e-06,
+                "stddev": 2.7203937164237688e-06,
+                "rounds": 5,
+                "median": 4.3089999053336214e-06,
+                "iqr": 2.0650001033573062e-06,
+                "q1": 3.7329999713620055e-06,
+                "q3": 5.798000074719312e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.6560001060715877e-06,
+                "hd15iqr": 9.748999900693889e-06,
+                "ops": 197730.0591480872,
+                "total": 2.5286999971285695e-05,
+                "data": [
+                    9.748999900693889e-06,
+                    4.091999926458811e-06,
+                    2.6560001060715877e-06,
+                    4.3089999053336214e-06,
+                    4.481000132727786e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00012870199998360476,
+                "max": 0.000422723999918162,
+                "mean": 0.0002117689999522554,
+                "stddev": 0.00012381115592955612,
+                "rounds": 5,
+                "median": 0.00014649599984295492,
+                "iqr": 0.00013796874986837793,
+                "q1": 0.00013529000005974012,
+                "q3": 0.00027325874992811805,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00012870199998360476,
+                "hd15iqr": 0.000422723999918162,
+                "ops": 4722.126469055697,
+                "total": 0.001058844999761277,
+                "data": [
+                    0.000422723999918162,
+                    0.00014649599984295492,
+                    0.00012870199998360476,
+                    0.00022343699993143673,
+                    0.00013748600008511858
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic-pop1",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_population_1_nucleotide_diversity_population": 0.018553479908472423
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.469000037308433e-06,
+                "max": 8.729999990464421e-06,
+                "mean": 3.897600026903092e-06,
+                "stddev": 2.7179281054746625e-06,
+                "rounds": 5,
+                "median": 2.5910001113516046e-06,
+                "iqr": 2.094750016112812e-06,
+                "q1": 2.489249993686826e-06,
+                "q3": 4.584000009799638e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.469000037308433e-06,
+                "hd15iqr": 8.729999990464421e-06,
+                "ops": 256568.14272822344,
+                "total": 1.948800013451546e-05,
+                "data": [
+                    8.729999990464421e-06,
+                    3.2020000162447104e-06,
+                    2.5910001113516046e-06,
+                    2.4959999791462906e-06,
+                    2.469000037308433e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic-pop2",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_population_2_nucleotide_diversity_population": 0.022956105762318782
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4949999897216912e-06,
+                "max": 7.5010000273323385e-06,
+                "mean": 4.0182000248023545e-06,
+                "stddev": 2.1502356506636182e-06,
+                "rounds": 5,
+                "median": 2.8130000373494113e-06,
+                "iqr": 2.8625001959881047e-06,
+                "q1": 2.548999930240825e-06,
+                "q3": 5.41150012622893e-06,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 2.4949999897216912e-06,
+                "hd15iqr": 7.5010000273323385e-06,
+                "ops": 248867.65064643283,
+                "total": 2.009100012401177e-05,
+                "data": [
+                    7.5010000273323385e-06,
+                    2.8130000373494113e-06,
+                    2.5669999104138697e-06,
+                    2.4949999897216912e-06,
+                    4.71500015919446e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00015033399995445507,
+                "max": 0.0003664089999801945,
+                "mean": 0.00021007379996262898,
+                "stddev": 9.279702021132082e-05,
+                "rounds": 5,
+                "median": 0.00015802199982317688,
+                "iqr": 0.00010947974976716068,
+                "q1": 0.00015070450012899528,
+                "q3": 0.00026018424989615596,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00015033399995445507,
+                "hd15iqr": 0.0003664089999801945,
+                "ops": 4760.231881262179,
+                "total": 0.001050368999813145,
+                "data": [
+                    0.0003664089999801945,
+                    0.00022477599986814312,
+                    0.00015802199982317688,
+                    0.00015082800018717535,
+                    0.00015033399995445507
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[pilot_panel_variants_512_samples_48-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00012525099987215071,
+                "max": 0.0002573390001998632,
+                "mean": 0.00017503840008430415,
+                "stddev": 6.310055796495634e-05,
+                "rounds": 5,
+                "median": 0.00013318200012690795,
+                "iqr": 0.00010710850000350547,
+                "q1": 0.0001290520000907236,
+                "q3": 0.00023616050009422906,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00012525099987215071,
+                "hd15iqr": 0.0002573390001998632,
+                "ops": 5713.032109059313,
+                "total": 0.0008751920004215208,
+                "data": [
+                    0.00022910100005901768,
+                    0.00013318200012690795,
+                    0.00012525099987215071,
+                    0.00013031900016358122,
+                    0.0002573390001998632
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_watterson_theta": 0.02890681886224518
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.340001164062414e-07,
+                "max": 1.59359999543085e-05,
+                "mean": 4.008999985671835e-06,
+                "stddev": 6.6884527904814625e-06,
+                "rounds": 5,
+                "median": 8.009999419300584e-07,
+                "iqr": 4.729999943720031e-06,
+                "q1": 7.090000053722179e-07,
+                "q3": 5.438999949092249e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 6.340001164062414e-07,
+                "hd15iqr": 1.59359999543085e-05,
+                "ops": 249438.76367523067,
+                "total": 2.0044999928359175e-05,
+                "data": [
+                    1.59359999543085e-05,
+                    1.939999947353499e-06,
+                    8.009999419300584e-07,
+                    7.339999683608767e-07,
+                    6.340001164062414e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 9.659599982114742e-05,
+                "max": 0.00023920799981169694,
+                "mean": 0.00013868699993508927,
+                "stddev": 5.814165555166151e-05,
+                "rounds": 5,
+                "median": 0.00012770600005751476,
+                "iqr": 5.6850249904982775e-05,
+                "q1": 9.977224999602186e-05,
+                "q3": 0.00015662249990100463,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 9.659599982114742e-05,
+                "hd15iqr": 0.00023920799981169694,
+                "ops": 7210.481158782277,
+                "total": 0.0006934349996754463,
+                "data": [
+                    0.00023920799981169694,
+                    0.00012909399993077386,
+                    0.00012770600005751476,
+                    0.00010083100005431334,
+                    9.659599982114742e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "pilot_panel_variants_512_samples_48-ferromic",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "ferromic",
+                "fst": 0.008230076904854725,
+                "d_xy": 0.012796184802120558,
+                "relative_to_scikit_pilot_panel_variants_512_samples_48_hudson_fst": 0.04601008084356619
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.254999900396797e-06,
+                "max": 2.629400000841997e-05,
+                "mean": 1.1501600010888068e-05,
+                "stddev": 8.301750015426995e-06,
+                "rounds": 5,
+                "median": 7.469999900422408e-06,
+                "iqr": 5.994999924041622e-06,
+                "q1": 7.379500118531723e-06,
+                "q3": 1.3374500042573345e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.254999900396797e-06,
+                "hd15iqr": 2.629400000841997e-05,
+                "ops": 86944.42504115455,
+                "total": 5.7508000054440345e-05,
+                "data": [
+                    2.629400000841997e-05,
+                    9.068000053957803e-06,
+                    7.469999900422408e-06,
+                    7.254999900396797e-06,
+                    7.421000191243365e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[pilot_panel_variants_512_samples_48-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='pilot_panel', variant_count=512, sample_count=48, divergence_scale=0.02, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "pilot_panel_variants_512_samples_48-scikit-allel",
+            "extra_info": {
+                "dataset": "pilot_panel_variants_512_samples_48",
+                "implementation": "scikit-allel",
+                "fst": 0.008230076904854744,
+                "d_xy": 0.012796184802120558
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00020852100010415597,
+                "max": 0.0003739989999758109,
+                "mean": 0.00024998000003506604,
+                "stddev": 6.988361851541923e-05,
+                "rounds": 5,
+                "median": 0.00022119499999462278,
+                "iqr": 5.482225009245667e-05,
+                "q1": 0.00021272325000154524,
+                "q3": 0.0002675455000940019,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00020852100010415597,
+                "hd15iqr": 0.0003739989999758109,
+                "ops": 4000.320025040902,
+                "total": 0.0012499000001753302,
+                "data": [
+                    0.0003739989999758109,
+                    0.00023206100013339892,
+                    0.00020852100010415597,
+                    0.00021412399996734166,
+                    0.00022119499999462278
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_segregating_sites": 0.03189221352845594
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.942000037364778e-06,
+                "max": 1.2016999789921101e-05,
+                "mean": 4.828800047107506e-06,
+                "stddev": 4.020107964394271e-06,
+                "rounds": 5,
+                "median": 2.989000222441973e-06,
+                "iqr": 2.4772499500613776e-06,
+                "q1": 2.954750073058676e-06,
+                "q3": 5.432000023120054e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.942000037364778e-06,
+                "hd15iqr": 1.2016999789921101e-05,
+                "ops": 207090.7865814425,
+                "total": 2.4144000235537533e-05,
+                "data": [
+                    1.2016999789921101e-05,
+                    3.237000100853038e-06,
+                    2.989000222441973e-06,
+                    2.942000037364778e-06,
+                    2.9590000849566422e-06
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 8.373899981961586e-05,
+                "max": 0.000327346999938527,
+                "mean": 0.00015140999989853298,
+                "stddev": 0.00010450026235752146,
+                "rounds": 5,
+                "median": 8.881399980964488e-05,
+                "iqr": 0.00012077899981477458,
+                "q1": 8.742750003420952e-05,
+                "q3": 0.0002082064998489841,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 8.373899981961586e-05,
+                "hd15iqr": 0.000327346999938527,
+                "ops": 6604.583585431262,
+                "total": 0.0007570499994926649,
+                "data": [
+                    0.000327346999938527,
+                    0.00016849299981913646,
+                    8.881399980964488e-05,
+                    8.865700010574074e-05,
+                    8.373899981961586e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_nucleotide_diversity": 0.0481997305093758
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.812300001802214e-05,
+                "max": 2.519399981792958e-05,
+                "mean": 1.9625599952632912e-05,
+                "stddev": 3.116614320658357e-06,
+                "rounds": 5,
+                "median": 1.8186000033892924e-05,
+                "iqr": 2.042999938112189e-06,
+                "q1": 1.8127499970432837e-05,
+                "q3": 2.0170499908545025e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.812300001802214e-05,
+                "hd15iqr": 2.519399981792958e-05,
+                "ops": 50953.85631081525,
+                "total": 9.812799976316455e-05,
+                "data": [
+                    2.519399981792958e-05,
+                    1.8495999938750174e-05,
+                    1.8186000033892924e-05,
+                    1.812300001802214e-05,
+                    1.8128999954569736e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00029833700000381214,
+                "max": 0.0007463290000941925,
+                "mean": 0.0004071724000368704,
+                "stddev": 0.00019050029689922715,
+                "rounds": 5,
+                "median": 0.00033455700008744316,
+                "iqr": 0.0001375542500454685,
+                "q1": 0.0003080457499891054,
+                "q3": 0.0004456000000345739,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00029833700000381214,
+                "hd15iqr": 0.0007463290000941925,
+                "ops": 2455.962142594753,
+                "total": 0.002035862000184352,
+                "data": [
+                    0.0007463290000941925,
+                    0.00034535700001470104,
+                    0.00029833700000381214,
+                    0.00033455700008744316,
+                    0.00031128199998420314
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic-pop1",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_population_1_nucleotide_diversity_population": 0.04341998914302607
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.5760999986014212e-05,
+                "max": 2.2844000113764196e-05,
+                "mean": 1.725460001580359e-05,
+                "stddev": 3.127853200106151e-06,
+                "rounds": 5,
+                "median": 1.5781999991304474e-05,
+                "iqr": 2.013750020068983e-06,
+                "q1": 1.577599999791346e-05,
+                "q3": 1.7789750017982442e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.5760999986014212e-05,
+                "hd15iqr": 2.2844000113764196e-05,
+                "ops": 57955.55962375796,
+                "total": 8.627300007901795e-05,
+                "data": [
+                    2.2844000113764196e-05,
+                    1.610499998605519e-05,
+                    1.5781999991304474e-05,
+                    1.5781000001879875e-05,
+                    1.5760999986014212e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic-pop2",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_population_2_nucleotide_diversity_population": 0.06315911228056793
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.574800012349442e-05,
+                "max": 3.871500007335271e-05,
+                "mean": 2.4793400052658397e-05,
+                "stddev": 9.87846375236409e-06,
+                "rounds": 5,
+                "median": 2.3358000134976464e-05,
+                "iqr": 1.6699250068086258e-05,
+                "q1": 1.576299996486341e-05,
+                "q3": 3.246225003294967e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 1.574800012349442e-05,
+                "hd15iqr": 3.871500007335271e-05,
+                "ops": 40333.31442545646,
+                "total": 0.000123967000263292,
+                "data": [
+                    3.871500007335271e-05,
+                    3.0378000019481988e-05,
+                    2.3358000134976464e-05,
+                    1.574800012349442e-05,
+                    1.5767999911986408e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0003063190001739713,
+                "max": 0.0005450529999961873,
+                "mean": 0.0003973884000515682,
+                "stddev": 9.027547617535324e-05,
+                "rounds": 5,
+                "median": 0.0003722020001077908,
+                "iqr": 9.897899997213244e-05,
+                "q1": 0.0003431950000276629,
+                "q3": 0.00044217399999979534,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0003063190001739713,
+                "hd15iqr": 0.0005450529999961873,
+                "ops": 2516.4297696415706,
+                "total": 0.001986942000257841,
+                "data": [
+                    0.0005450529999961873,
+                    0.0003722020001077908,
+                    0.0003063190001739713,
+                    0.00035548699997889344,
+                    0.00040788100000099803
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[regional_panel_variants_4096_samples_96-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0003318429999126238,
+                "max": 0.00045593699996970827,
+                "mean": 0.00039255459992091344,
+                "stddev": 5.917704149363392e-05,
+                "rounds": 5,
+                "median": 0.00039303999983530957,
+                "iqr": 0.00011520575009171807,
+                "q1": 0.0003341019998970296,
+                "q3": 0.0004493077499887477,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0003318429999126238,
+                "hd15iqr": 0.00045593699996970827,
+                "ops": 2547.4163344448552,
+                "total": 0.0019627729996045673,
+                "data": [
+                    0.00045593699996970827,
+                    0.00039303999983530957,
+                    0.00044709799999509414,
+                    0.0003318429999126238,
+                    0.00033485499989183154
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_watterson_theta": 0.01122263471873019
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.730001587129664e-07,
+                "max": 1.2491000006775721e-05,
+                "mean": 3.1504000617132988e-06,
+                "stddev": 5.2244282443129785e-06,
+                "rounds": 5,
+                "median": 7.650000952708069e-07,
+                "iqr": 3.2522500532650156e-06,
+                "q1": 7.03000011981203e-07,
+                "q3": 3.955250065246219e-06,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 6.730001587129664e-07,
+                "hd15iqr": 1.2491000006775721e-05,
+                "ops": 317420.00393948844,
+                "total": 1.5752000308566494e-05,
+                "data": [
+                    1.2491000006775721e-05,
+                    1.1100000847363845e-06,
+                    7.650000952708069e-07,
+                    6.730001587129664e-07,
+                    7.129999630706152e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0002273210000112158,
+                "max": 0.0004600639999807754,
+                "mean": 0.0002807183999721019,
+                "stddev": 0.00010105908152248726,
+                "rounds": 5,
+                "median": 0.0002309809999587742,
+                "iqr": 8.087925010613617e-05,
+                "q1": 0.00022744324991208487,
+                "q3": 0.00030832250001822104,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0002273210000112158,
+                "hd15iqr": 0.0004600639999807754,
+                "ops": 3562.288756630777,
+                "total": 0.0014035919998605095,
+                "data": [
+                    0.0004600639999807754,
+                    0.0002577420000307029,
+                    0.0002309809999587742,
+                    0.0002273210000112158,
+                    0.00022748399987904122
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "ferromic"
+            },
+            "param": "regional_panel_variants_4096_samples_96-ferromic",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "ferromic",
+                "fst": 0.028746943727020604,
+                "d_xy": 0.012981536777004749,
+                "relative_to_scikit_regional_panel_variants_4096_samples_96_hudson_fst": 0.07764232125739963
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.912699978376622e-05,
+                "max": 8.459200012111978e-05,
+                "mean": 5.6431199982398536e-05,
+                "stddev": 1.5745780664029022e-05,
+                "rounds": 5,
+                "median": 4.925099983665859e-05,
+                "iqr": 9.406250171650754e-06,
+                "q1": 4.920649996620341e-05,
+                "q3": 5.8612750137854164e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 4.912699978376622e-05,
+                "hd15iqr": 8.459200012111978e-05,
+                "ops": 17720.693522588746,
+                "total": 0.0002821559999119927,
+                "data": [
+                    8.459200012111978e-05,
+                    4.995300014343229e-05,
+                    4.925099983665859e-05,
+                    4.912699978376622e-05,
+                    4.9233000027015805e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[regional_panel_variants_4096_samples_96-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='regional_panel', variant_count=4096, sample_count=96, divergence_scale=0.05, benchmark_rounds=5)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "regional_panel_variants_4096_samples_96-scikit-allel",
+            "extra_info": {
+                "dataset": "regional_panel_variants_4096_samples_96",
+                "implementation": "scikit-allel",
+                "fst": 0.028746943727020562,
+                "d_xy": 0.012981536777004777
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0006493779999345861,
+                "max": 0.0008208640001612366,
+                "mean": 0.0007268097999713063,
+                "stddev": 7.370725485562107e-05,
+                "rounds": 5,
+                "median": 0.0007035179999093089,
+                "iqr": 0.00012722175006274483,
+                "q1": 0.0006677777499248805,
+                "q3": 0.0007949994999876253,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0006493779999345861,
+                "hd15iqr": 0.0008208640001612366,
+                "ops": 1375.8757793847565,
+                "total": 0.0036340489998565317,
+                "data": [
+                    0.0008208640001612366,
+                    0.0007863779999297549,
+                    0.0006739109999216453,
+                    0.0006493779999345861,
+                    0.0007035179999093089
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_segregating_sites": 0.0498490098080556
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.0195999948336976e-05,
+                "max": 3.680700001496007e-05,
+                "mean": 1.899174992558983e-05,
+                "stddev": 1.2130273742032843e-05,
+                "rounds": 4,
+                "median": 1.4481999869531137e-05,
+                "iqr": 1.5038500123409904e-05,
+                "q1": 1.1472499863884877e-05,
+                "q3": 2.651099998729478e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 1.0195999948336976e-05,
+                "hd15iqr": 3.680700001496007e-05,
+                "ops": 52654.442266669794,
+                "total": 7.596699970235932e-05,
+                "data": [
+                    3.680700001496007e-05,
+                    1.6214999959629495e-05,
+                    1.274899977943278e-05,
+                    1.0195999948336976e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00029623099999298574,
+                "max": 0.0005865890000222862,
+                "mean": 0.00038098549998721865,
+                "stddev": 0.00013864558034487926,
+                "rounds": 4,
+                "median": 0.0003205609999668013,
+                "iqr": 0.00016650299994580564,
+                "q1": 0.0002977340000143158,
+                "q3": 0.00046423699996012147,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00029623099999298574,
+                "hd15iqr": 0.0005865890000222862,
+                "ops": 2624.77180898892,
+                "total": 0.0015239419999488746,
+                "data": [
+                    0.0005865890000222862,
+                    0.00034188499989795673,
+                    0.0002992370000356459,
+                    0.00029623099999298574
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_nucleotide_diversity": 0.06437860801716944
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.065999989208649e-05,
+                "max": 0.00010833300007107027,
+                "mean": 8.224100002962587e-05,
+                "stddev": 1.7802000850750717e-05,
+                "rounds": 4,
+                "median": 7.498550007767335e-05,
+                "iqr": 2.2744000148122723e-05,
+                "q1": 7.08689999555645e-05,
+                "q3": 9.361300010368723e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 7.065999989208649e-05,
+                "hd15iqr": 0.00010833300007107027,
+                "ops": 12159.385217102998,
+                "total": 0.00032896400011850346,
+                "data": [
+                    7.889300013630418e-05,
+                    0.00010833300007107027,
+                    7.107800001904252e-05,
+                    7.065999989208649e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.001069225000037477,
+                "max": 0.0015135779999582155,
+                "mean": 0.0012774584999988292,
+                "stddev": 0.00018321558743306503,
+                "rounds": 4,
+                "median": 0.0012635154999998122,
+                "iqr": 0.0002466859998548898,
+                "q1": 0.0011541155000713843,
+                "q3": 0.0014008014999262741,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.001069225000037477,
+                "hd15iqr": 0.0015135779999582155,
+                "ops": 782.8042946216386,
+                "total": 0.005109833999995317,
+                "data": [
+                    0.0015135779999582155,
+                    0.0012390060001052916,
+                    0.001069225000037477,
+                    0.0012880249998943327
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic-pop1",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_population_1_nucleotide_diversity_population": 0.0860372022493396
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.209499995042279e-05,
+                "max": 0.00011411500008762232,
+                "mean": 0.00010069450001992664,
+                "stddev": 1.9624163552965944e-05,
+                "rounds": 4,
+                "median": 0.00010828400002083072,
+                "iqr": 2.559700010351662e-05,
+                "q1": 8.789599996816833e-05,
+                "q3": 0.00011349300007168495,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 7.209499995042279e-05,
+                "hd15iqr": 0.00011411500008762232,
+                "ops": 9931.029001604933,
+                "total": 0.00040277800007970654,
+                "data": [
+                    0.00010369699998591386,
+                    7.209499995042279e-05,
+                    0.00011287100005574757,
+                    0.00011411500008762232
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic-pop2",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_population_2_nucleotide_diversity_population": 0.09044305509696172
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.189700002323661e-05,
+                "max": 0.00015547800012427615,
+                "mean": 9.546425002326941e-05,
+                "stddev": 4.115652077679519e-05,
+                "rounds": 4,
+                "median": 8.224099997278245e-05,
+                "iqr": 4.8105500013662095e-05,
+                "q1": 7.141150001643837e-05,
+                "q3": 0.00011951700003010046,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 6.189700002323661e-05,
+                "hd15iqr": 0.00015547800012427615,
+                "ops": 10475.125502544146,
+                "total": 0.00038185700009307766,
+                "data": [
+                    0.00015547800012427615,
+                    8.355599993592477e-05,
+                    8.092600000964012e-05,
+                    6.189700002323661e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0009898379998958262,
+                "max": 0.001293632999932015,
+                "mean": 0.0011703599999464132,
+                "stddev": 0.00014830503146259045,
+                "rounds": 4,
+                "median": 0.0011989844999789057,
+                "iqr": 0.00024289199996019306,
+                "q1": 0.0010489139999663166,
+                "q3": 0.0012918059999265097,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0009898379998958262,
+                "hd15iqr": 0.001293632999932015,
+                "ops": 854.4379507551408,
+                "total": 0.004681439999785653,
+                "data": [
+                    0.001293632999932015,
+                    0.0012899789999210043,
+                    0.001107990000036807,
+                    0.0009898379998958262
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[chromosome_arm_variants_16384_samples_128-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0009938040000179171,
+                "max": 0.0011119330001747585,
+                "mean": 0.0010555177500464197,
+                "stddev": 6.401282654762243e-05,
+                "rounds": 4,
+                "median": 0.0010581669999965015,
+                "iqr": 0.00011048250007661409,
+                "q1": 0.0010002765000081126,
+                "q3": 0.0011107590000847267,
+                "iqr_outliers": 0,
+                "stddev_outliers": 0,
+                "outliers": "0;0",
+                "ld15iqr": 0.0009938040000179171,
+                "hd15iqr": 0.0011119330001747585,
+                "ops": 947.4023529741891,
+                "total": 0.004222071000185679,
+                "data": [
+                    0.0011119330001747585,
+                    0.0010067489999983081,
+                    0.0009938040000179171,
+                    0.001109584999994695
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_watterson_theta": 0.004909817851502413
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.709999524900923e-07,
+                "max": 1.3081999895803165e-05,
+                "mean": 3.9169999013211054e-06,
+                "stddev": 6.113191359764338e-06,
+                "rounds": 4,
+                "median": 9.574998784955824e-07,
+                "iqr": 6.381999924087722e-06,
+                "q1": 7.259999392772443e-07,
+                "q3": 7.107999863364967e-06,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 6.709999524900923e-07,
+                "hd15iqr": 1.3081999895803165e-05,
+                "ops": 255297.427927615,
+                "total": 1.5667999605284422e-05,
+                "data": [
+                    1.3081999895803165e-05,
+                    1.1339998309267685e-06,
+                    7.809999260643963e-07,
+                    6.709999524900923e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0006742640000538813,
+                "max": 0.0009149019999767916,
+                "mean": 0.0007977892499866357,
+                "stddev": 0.00011560336042551418,
+                "rounds": 4,
+                "median": 0.000800995499957935,
+                "iqr": 0.00019481050003378186,
+                "q1": 0.0007003839999697448,
+                "q3": 0.0008951945000035266,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0006742640000538813,
+                "hd15iqr": 0.0009149019999767916,
+                "ops": 1253.4638690816548,
+                "total": 0.0031911569999465428,
+                "data": [
+                    0.0009149019999767916,
+                    0.0008754870000302617,
+                    0.0007265039998856082,
+                    0.0006742640000538813
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "ferromic"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-ferromic",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "ferromic",
+                "fst": 0.06676412120482449,
+                "d_xy": 0.013018435627179586,
+                "relative_to_scikit_chromosome_arm_variants_16384_samples_128_hudson_fst": 0.12513951286972777
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00022775299999011622,
+                "max": 0.0003490320000310021,
+                "mean": 0.00029930925001053765,
+                "stddev": 5.1673330727247134e-05,
+                "rounds": 4,
+                "median": 0.00031022600001051615,
+                "iqr": 7.011049990524043e-05,
+                "q1": 0.00026425400005791744,
+                "q3": 0.00033436449996315787,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00022775299999011622,
+                "hd15iqr": 0.0003490320000310021,
+                "ops": 3341.0260456861706,
+                "total": 0.0011972370000421506,
+                "data": [
+                    0.00030075500012571865,
+                    0.00022775299999011622,
+                    0.0003490320000310021,
+                    0.00031969699989531364
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[chromosome_arm_variants_16384_samples_128-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='chromosome_arm', variant_count=16384, sample_count=128, divergence_scale=0.08, benchmark_rounds=4)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "chromosome_arm_variants_16384_samples_128-scikit-allel",
+            "extra_info": {
+                "dataset": "chromosome_arm_variants_16384_samples_128",
+                "implementation": "scikit-allel",
+                "fst": 0.06676412120482433,
+                "d_xy": 0.013018435627179586
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002286206000007951,
+                "max": 0.0026104030000624334,
+                "mean": 0.0023918045000073107,
+                "stddev": 0.00015030724204732678,
+                "rounds": 4,
+                "median": 0.0023353044999794292,
+                "iqr": 0.00019714099994416756,
+                "q1": 0.002293234000035227,
+                "q3": 0.0024903749999793945,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.002286206000007951,
+                "hd15iqr": 0.0026104030000624334,
+                "ops": 418.0943718422402,
+                "total": 0.009567218000029243,
+                "data": [
+                    0.0026104030000624334,
+                    0.0023703469998963556,
+                    0.002286206000007951,
+                    0.002300262000062503
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_segregating_sites": 0.057128052239142114
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 3.942500006814953e-05,
+                "max": 0.00016869599994606688,
+                "mean": 8.566366667158339e-05,
+                "stddev": 7.206301605320414e-05,
+                "rounds": 3,
+                "median": 4.8870000000533764e-05,
+                "iqr": 9.695324990843801e-05,
+                "q1": 4.178625005124559e-05,
+                "q3": 0.0001387394999596836,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 3.942500006814953e-05,
+                "hd15iqr": 0.00016869599994606688,
+                "ops": 11673.560552034169,
+                "total": 0.00025699100001475017,
+                "data": [
+                    0.00016869599994606688,
+                    4.8870000000533764e-05,
+                    3.942500006814953e-05
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.001339652000069691,
+                "max": 0.0017587479999292555,
+                "mean": 0.0014995026666232054,
+                "stddev": 0.00022653882472703813,
+                "rounds": 3,
+                "median": 0.00140010799987067,
+                "iqr": 0.00031432199989467335,
+                "q1": 0.0013547660000199357,
+                "q3": 0.001669087999914609,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.001339652000069691,
+                "hd15iqr": 0.0017587479999292555,
+                "ops": 666.8877770333967,
+                "total": 0.0044985079998696165,
+                "data": [
+                    0.0017587479999292555,
+                    0.001339652000069691,
+                    0.00140010799987067
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_nucleotide_diversity": 0.07104466248651871
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0002563180000834109,
+                "max": 0.00033291999989160104,
+                "mean": 0.0002846866666459391,
+                "stddev": 4.198714482407077e-05,
+                "rounds": 3,
+                "median": 0.0002648219999628054,
+                "iqr": 5.745149985614262e-05,
+                "q1": 0.0002584440000532595,
+                "q3": 0.00031589549990940213,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0002563180000834109,
+                "hd15iqr": 0.00033291999989160104,
+                "ops": 3512.6337730585965,
+                "total": 0.0008540599999378173,
+                "data": [
+                    0.0002648219999628054,
+                    0.00033291999989160104,
+                    0.0002563180000834109
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003561801999921954,
+                "max": 0.004761191999932635,
+                "mean": 0.004007150666666348,
+                "stddev": 0.0006565839358411858,
+                "rounds": 3,
+                "median": 0.0036984580001444556,
+                "iqr": 0.0008995425000080104,
+                "q1": 0.0035959659999775795,
+                "q3": 0.00449550849998559,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.003561801999921954,
+                "hd15iqr": 0.004761191999932635,
+                "ops": 249.55388084569472,
+                "total": 0.012021451999999044,
+                "data": [
+                    0.004761191999932635,
+                    0.0036984580001444556,
+                    0.003561801999921954
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic",
+                "population_key": "pop1"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic-pop1",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_1",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_population_1_nucleotide_diversity_population": 0.07174399863827896
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0002458430001297529,
+                "max": 0.00030730599996786623,
+                "mean": 0.00027316233331475814,
+                "stddev": 3.129462785747549e-05,
+                "rounds": 3,
+                "median": 0.0002663379998466553,
+                "iqr": 4.609724987858499e-05,
+                "q1": 0.0002509667500589785,
+                "q3": 0.0002970639999375635,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0002458430001297529,
+                "hd15iqr": 0.00030730599996786623,
+                "ops": 3660.8268345977444,
+                "total": 0.0008194869999442744,
+                "data": [
+                    0.00030730599996786623,
+                    0.0002663379998466553,
+                    0.0002458430001297529
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-ferromic-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic",
+                "population_key": "pop2"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic-pop2",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_2",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_population_2_nucleotide_diversity_population": 0.0712675743138323
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0002444750000449858,
+                "max": 0.0002818010000282811,
+                "mean": 0.0002641753333894788,
+                "stddev": 1.8749286656910895e-05,
+                "rounds": 3,
+                "median": 0.0002662500000951695,
+                "iqr": 2.79944999874715e-05,
+                "q1": 0.0002499187500575317,
+                "q3": 0.0002779132500450032,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0002444750000449858,
+                "hd15iqr": 0.0002818010000282811,
+                "ops": 3785.3647695626473,
+                "total": 0.0007925260001684364,
+                "data": [
+                    0.0002818010000282811,
+                    0.0002662500000951695,
+                    0.0002444750000449858
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop1]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop1]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop1"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel-pop1",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_1",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003605305000064618,
+                "max": 0.004176840000127413,
+                "mean": 0.00380745900004816,
+                "stddev": 0.00032036965562448817,
+                "rounds": 3,
+                "median": 0.003640231999952448,
+                "iqr": 0.00042865125004709626,
+                "q1": 0.0036140367500365755,
+                "q3": 0.004042688000083672,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.003605305000064618,
+                "hd15iqr": 0.004176840000127413,
+                "ops": 262.6423554363557,
+                "total": 0.011422377000144479,
+                "data": [
+                    0.004176840000127413,
+                    0.003605305000064618,
+                    0.003640231999952448
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop2]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_population_nucleotide_diversity[deep_cohort_variants_65536_samples_256-scikit-allel-pop2]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel",
+                "population_key": "pop2"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel-pop2",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "population": "population_2",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003612027000144735,
+                "max": 0.0038296440000067378,
+                "mean": 0.003706809666709887,
+                "stddev": 0.00011148749554122394,
+                "rounds": 3,
+                "median": 0.0036787579999781883,
+                "iqr": 0.00016321274989650192,
+                "q1": 0.0036287097501030985,
+                "q3": 0.0037919224999996004,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.003612027000144735,
+                "hd15iqr": 0.0038296440000067378,
+                "ops": 269.77376501976863,
+                "total": 0.011120429000129661,
+                "data": [
+                    0.0038296440000067378,
+                    0.0036787579999781883,
+                    0.003612027000144735
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_watterson_theta": 0.00215547986114886
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.400001322821481e-07,
+                "max": 1.6999000081341364e-05,
+                "mean": 6.306333413400959e-06,
+                "stddev": 9.262733955507316e-06,
+                "rounds": 3,
+                "median": 1.1800000265793642e-06,
+                "iqr": 1.2194249961794412e-05,
+                "q1": 8.500001058564521e-07,
+                "q3": 1.3044250067650864e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 7.400001322821481e-07,
+                "hd15iqr": 1.6999000081341364e-05,
+                "ops": 158570.74696922937,
+                "total": 1.8919000240202877e-05,
+                "data": [
+                    1.6999000081341364e-05,
+                    1.1800000265793642e-06,
+                    7.400001322821481e-07
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_watterson_theta[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel"
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002640347000124166,
+                "max": 0.0032943339999746968,
+                "mean": 0.0029257213333645873,
+                "stddev": 0.00033484505984111076,
+                "rounds": 3,
+                "median": 0.0028424829999948997,
+                "iqr": 0.0004904902498878982,
+                "q1": 0.0026908810000918493,
+                "q3": 0.0031813712499797475,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.002640347000124166,
+                "hd15iqr": 0.0032943339999746968,
+                "ops": 341.79605165950557,
+                "total": 0.008777164000093762,
+                "data": [
+                    0.0032943339999746968,
+                    0.0028424829999948997,
+                    0.002640347000124166
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-ferromic]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-ferromic]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "ferromic"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-ferromic",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "ferromic",
+                "fst": 0.09871859560569146,
+                "d_xy": 0.01341475163945433,
+                "relative_to_scikit_deep_cohort_variants_65536_samples_256_hudson_fst": 0.10511827368757713
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0009352930001114146,
+                "max": 0.001140578999866193,
+                "mean": 0.0010452766666730895,
+                "stddev": 0.00010342747017083552,
+                "rounds": 3,
+                "median": 0.0010599580000416609,
+                "iqr": 0.00015396449981608384,
+                "q1": 0.0009664592500939762,
+                "q3": 0.00112042374991006,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0009352930001114146,
+                "hd15iqr": 0.001140578999866193,
+                "ops": 956.684514141891,
+                "total": 0.0031358300000192685,
+                "data": [
+                    0.001140578999866193,
+                    0.0010599580000416609,
+                    0.0009352930001114146
+                ],
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "fullname": "src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_hudson_fst_result[deep_cohort_variants_65536_samples_256-scikit-allel]",
+            "params": {
+                "genotype_dataset": "UNSERIALIZABLE[DatasetConfig(label='deep_cohort', variant_count=65536, sample_count=256, divergence_scale=0.1, benchmark_rounds=3)]",
+                "implementation": "scikit-allel"
+            },
+            "param": "deep_cohort_variants_65536_samples_256-scikit-allel",
+            "extra_info": {
+                "dataset": "deep_cohort_variants_65536_samples_256",
+                "implementation": "scikit-allel",
+                "fst": 0.0987185956056903,
+                "d_xy": 0.01341475163945433
+            },
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00914657599992097,
+                "max": 0.011136577000115722,
+                "mean": 0.009943815000042378,
+                "stddev": 0.0010523092833441426,
+                "rounds": 3,
+                "median": 0.009548292000090441,
+                "iqr": 0.001492500750146064,
+                "q1": 0.009247004999963337,
+                "q3": 0.010739505750109402,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.00914657599992097,
+                "hd15iqr": 0.011136577000115722,
+                "ops": 100.56502459023406,
+                "total": 0.029831445000127133,
+                "data": [
+                    0.011136577000115722,
+                    0.009548292000090441,
+                    0.00914657599992097
+                ],
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2025-09-20T02:27:39.008616+00:00",
+    "version": "5.1.0"
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,9 +1,9 @@
 use crate::process::{ConfigEntry, VcfError, ZeroBasedHalfOpen};
-use crate::transcripts::TranscriptAnnotationCDS;
 use crate::progress::{
-    log, LogLevel, init_step_progress, update_step_progress,
-    finish_step_progress, create_spinner, set_stage, ProcessingStage
+    create_spinner, finish_step_progress, init_step_progress, log, set_stage, update_step_progress,
+    LogLevel, ProcessingStage,
 };
+use crate::transcripts::TranscriptAnnotationCDS;
 
 use flate2::read::MultiGzDecoder;
 use std::collections::{HashMap, HashSet};
@@ -17,8 +17,11 @@ pub fn parse_regions_file(
 ) -> Result<HashMap<String, Vec<ZeroBasedHalfOpen>>, VcfError> {
     set_stage(ProcessingStage::Global);
     let is_bed_file = path.extension().and_then(|s| s.to_str()) == Some("bed");
-    
-    log(LogLevel::Info, &format!("Parsing regions file: {}", path.display()));
+
+    log(
+        LogLevel::Info,
+        &format!("Parsing regions file: {}", path.display()),
+    );
 
     let file = File::open(path)?;
     let reader = BufReader::new(file);
@@ -76,7 +79,10 @@ pub fn parse_regions_file(
     }
 
     let num_regions: usize = regions.values().map(|v| v.len()).sum();
-    log(LogLevel::Info, &format!("Completed parsing {} regions", num_regions));
+    log(
+        LogLevel::Info,
+        &format!("Completed parsing {} regions", num_regions),
+    );
 
     Ok(regions)
 }
@@ -84,8 +90,11 @@ pub fn parse_regions_file(
 // Check 0-based vs. 1 based, half-open vs. inclusive, between config file and mask/allow file
 pub fn parse_config_file(path: &Path) -> Result<Vec<ConfigEntry>, VcfError> {
     set_stage(ProcessingStage::Global);
-    log(LogLevel::Info, &format!("Parsing config file: {}", path.display()));
-    
+    log(
+        LogLevel::Info,
+        &format!("Parsing config file: {}", path.display()),
+    );
+
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b'\t')
         .from_path(path)
@@ -193,10 +202,13 @@ pub fn parse_config_file(path: &Path) -> Result<Vec<ConfigEntry>, VcfError> {
         }
 
         if samples_unfiltered.is_empty() {
-            log(LogLevel::Warning, &format!(
-                "No valid genotypes found for region {}:{}-{}",
-                seqname, start_pos, end_pos
-            ));
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "No valid genotypes found for region {}:{}-{}",
+                    seqname, start_pos, end_pos
+                ),
+            );
             continue;
         }
 
@@ -240,13 +252,19 @@ pub fn parse_region(region: &str) -> Result<ZeroBasedHalfOpen, VcfError> {
     Ok(interval)
 }
 
-
 pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
     set_stage(ProcessingStage::Global);
-    log(LogLevel::Info, &format!("Searching for VCF file for chromosome {} in folder: {}", chr, folder));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Searching for VCF file for chromosome {} in folder: {}",
+            chr, folder
+        ),
+    );
 
     // Use a static flag to only show one VCF spinner at a time
-    static VCF_SPINNER_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    static VCF_SPINNER_ACTIVE: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
     let spinner = if !VCF_SPINNER_ACTIVE.swap(true, std::sync::atomic::Ordering::SeqCst) {
         // First spinner shows general message
         create_spinner("Loading VCF files")
@@ -261,25 +279,25 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
     let path = Path::new(folder);
     if !path.exists() {
         spinner.finish_and_clear();
-        log(LogLevel::Error, &format!(
-            "Error: Folder not found: {}",
-            folder
-        ));
+        log(
+            LogLevel::Error,
+            &format!("Error: Folder not found: {}", folder),
+        );
         return Err(VcfError::Io(io::Error::new(
             io::ErrorKind::NotFound,
-            format!("VCF folder does not exist: {}", folder)
+            format!("VCF folder does not exist: {}", folder),
         )));
     }
-    
+
     if !path.is_dir() {
         spinner.finish_and_clear();
-        log(LogLevel::Error, &format!(
-            "Error: Not a directory: {}",
-            folder
-        ));
+        log(
+            LogLevel::Error,
+            &format!("Error: Not a directory: {}", folder),
+        );
         return Err(VcfError::Io(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("VCF path is not a directory: {}", folder)
+            format!("VCF path is not a directory: {}", folder),
         )));
     }
 
@@ -294,41 +312,46 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         format!("{}.vcf.gz", chr),
         format!("{}.vcf", chr),
     ];
-    
-    spinner.set_message(format!("Searching for chromosome {} using standard patterns", chr));
-    
+
+    spinner.set_message(format!(
+        "Searching for chromosome {} using standard patterns",
+        chr
+    ));
+
     // Try exact match first
     for pattern in common_patterns {
         // Use glob for pattern matching
         let glob_pattern = format!("{}/{}", folder, pattern);
         if let Ok(glob_paths) = glob::glob(&glob_pattern) {
-            let matches: Vec<_> = glob_paths
-                .filter_map(Result::ok)
-                .collect();
+            let matches: Vec<_> = glob_paths.filter_map(Result::ok).collect();
             if !matches.is_empty() {
                 let file_path = &matches[0];
                 spinner.finish_and_clear();
-                log(LogLevel::Info, &format!(
-                    "Found VCF file: {}",
-                    file_path.display()
-                ));
-                log(LogLevel::Info, &format!("Found VCF file using pattern '{}': {}", pattern, file_path.display()));
+                log(
+                    LogLevel::Info,
+                    &format!("Found VCF file: {}", file_path.display()),
+                );
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Found VCF file using pattern '{}': {}",
+                        pattern,
+                        file_path.display()
+                    ),
+                );
                 return Ok(file_path.clone());
             }
         }
     }
-    
+
     // If exact patterns didn't work, try more flexible search
     spinner.set_message(format!("Searching for chromosome {} files", chr));
-    
+
     let entries = match fs::read_dir(path) {
         Ok(entries) => entries,
         Err(e) => {
             spinner.finish_and_clear();
-            log(LogLevel::Error, &format!(
-                "Error reading directory: {}",
-                e
-            ));
+            log(LogLevel::Error, &format!("Error reading directory: {}", e));
             return Err(VcfError::Io(e));
         }
     };
@@ -339,20 +362,22 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         .map(|entry| entry.path())
         .filter(|path| {
             let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            
+
             // Check if it's a valid VCF file (has .vcf or .vcf.gz extension)
             let is_vcf = vcf_extensions.iter().any(|ext| file_name.ends_with(ext));
-            
+
             // Ensure it's not an index or other auxiliary file
-            let not_auxiliary = !invalid_extensions.iter().any(|ext| file_name.ends_with(ext));
-            
+            let not_auxiliary = !invalid_extensions
+                .iter()
+                .any(|ext| file_name.ends_with(ext));
+
             // Check chromosome match
             let chr_pattern = format!("chr{}", chr);
-            let has_chr = file_name.starts_with(&chr_pattern) || 
-                          file_name.starts_with(chr) ||
-                          file_name.contains(&format!("_{}", chr)) ||
-                          file_name.contains(&format!("_{}_", chr));
-            
+            let has_chr = file_name.starts_with(&chr_pattern)
+                || file_name.starts_with(chr)
+                || file_name.contains(&format!("_{}", chr))
+                || file_name.contains(&format!("_{}_", chr));
+
             is_vcf && not_auxiliary && has_chr
         })
         .map(|path| {
@@ -361,39 +386,52 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
             let mut score: i32 = 0;
 
             // Prioritize standard naming patterns
-            if file_name == format!("chr{}.vcf.gz", chr) { score += 100; }
-            else if file_name == format!("chr{}.vcf", chr) { score += 90; }
-            else if file_name == format!("{}.vcf.gz", chr) { score += 80; }
-            else if file_name == format!("{}.vcf", chr) { score += 70; }
-            
+            if file_name == format!("chr{}.vcf.gz", chr) {
+                score += 100;
+            } else if file_name == format!("chr{}.vcf", chr) {
+                score += 90;
+            } else if file_name == format!("{}.vcf.gz", chr) {
+                score += 80;
+            } else if file_name == format!("{}.vcf", chr) {
+                score += 70;
+            }
+
             // Prefer compressed VCF files
-            if file_name.ends_with(".vcf.gz") { score += 15; }
-            
+            if file_name.ends_with(".vcf.gz") {
+                score += 15;
+            }
+
             // Prefer files with standard chromosome nomenclature
-            if file_name.starts_with(&format!("chr{}", chr)) { score += 10; }
-            else if file_name.starts_with(chr) { score += 5; }
-            
+            if file_name.starts_with(&format!("chr{}", chr)) {
+                score += 10;
+            } else if file_name.starts_with(chr) {
+                score += 5;
+            }
+
             // Penalize complex filenames (but not too much)
             score -= (file_name.len() / 5) as i32;
-            
+
             (path, score)
         })
         .collect();
-    
+
     // Sort by score (highest first)
     vcf_candidates.sort_by(|a, b| b.1.cmp(&a.1));
 
     if vcf_candidates.is_empty() {
         // No VCF files found for the specified chromosome
-        log(LogLevel::Warning, &format!(
-            "No VCF files found for chr{}",
-            chr
-        ));
-        log(LogLevel::Error, &format!(
-            "Could not find VCF files for chromosome {} in folder: {}", 
-            chr, folder
-        ));
-        
+        log(
+            LogLevel::Warning,
+            &format!("No VCF files found for chr{}", chr),
+        );
+        log(
+            LogLevel::Error,
+            &format!(
+                "Could not find VCF files for chromosome {} in folder: {}",
+                chr, folder
+            ),
+        );
+
         // Check if any VCF files exist to provide helpful error message
         let any_vcf_files: Vec<_> = fs::read_dir(path)
             .unwrap_or_else(|_| fs::read_dir(".").unwrap())
@@ -401,11 +439,11 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
             .filter(|entry| {
                 let file_name = entry.file_name();
                 let name = file_name.to_string_lossy();
-                vcf_extensions.iter().any(|ext| name.ends_with(ext)) &&
-                !invalid_extensions.iter().any(|ext| name.ends_with(ext))
+                vcf_extensions.iter().any(|ext| name.ends_with(ext))
+                    && !invalid_extensions.iter().any(|ext| name.ends_with(ext))
             })
             .collect();
-            
+
         if any_vcf_files.is_empty() {
             log(LogLevel::Error, &format!(
                 "No VCF files found in directory {}. Please check path is correct and contains VCF files.", 
@@ -414,27 +452,35 @@ pub fn find_vcf_file(folder: &str, chr: &str) -> Result<PathBuf, VcfError> {
         } else {
             log(LogLevel::Info, "Available VCF files in directory:");
             for file in any_vcf_files.iter().take(5) {
-                log(LogLevel::Info, &format!("  - {}", file.file_name().to_string_lossy()));
+                log(
+                    LogLevel::Info,
+                    &format!("  - {}", file.file_name().to_string_lossy()),
+                );
             }
             if any_vcf_files.len() > 5 {
-                log(LogLevel::Info, &format!("  ... and {} more", any_vcf_files.len() - 5));
+                log(
+                    LogLevel::Info,
+                    &format!("  ... and {} more", any_vcf_files.len() - 5),
+                );
             }
         }
-        
+
         Err(VcfError::NoVcfFiles)
     } else {
         // Select the highest scoring VCF file automatically
         let best_match = &vcf_candidates[0].0;
         spinner.finish_and_clear();
-        log(LogLevel::Info, &format!(
-            "Selected VCF file: {}",
-            best_match.display()
-        ));
-        log(LogLevel::Info, &format!("Selected best matching VCF file: {}", best_match.display()));
+        log(
+            LogLevel::Info,
+            &format!("Selected VCF file: {}", best_match.display()),
+        );
+        log(
+            LogLevel::Info,
+            &format!("Selected best matching VCF file: {}", best_match.display()),
+        );
         return Ok(best_match.clone());
     }
 }
-
 
 pub fn open_vcf_reader(path: &Path) -> Result<Box<dyn BufRead + Send>, VcfError> {
     let file = File::open(path)?;
@@ -471,19 +517,22 @@ pub fn read_reference_sequence(
 ) -> Result<Vec<u8>, VcfError> {
     set_stage(ProcessingStage::Global);
     // Log to file but don't create detailed spinner messages
-    log(LogLevel::Info, &format!(
-        "Reading reference sequence for chromosome {} from {}:{}-{}", 
-        chr, fasta_path.display(), region.start, region.end
-    ));
-    
+    log(
+        LogLevel::Info,
+        &format!(
+            "Reading reference sequence for chromosome {} from {}:{}-{}",
+            chr,
+            fasta_path.display(),
+            region.start,
+            region.end
+        ),
+    );
+
     // Create reader for the FASTA file and its index
     let mut reader = bio::io::fasta::IndexedReader::from_file(&fasta_path).map_err(|e| {
         let error_msg = format!("Failed to open FASTA file: {}", e);
         log(LogLevel::Error, &error_msg);
-        VcfError::Io(io::Error::new(
-            io::ErrorKind::Other,
-            error_msg,
-        ))
+        VcfError::Io(io::Error::new(io::ErrorKind::Other, error_msg))
     })?;
 
     // Try both with and without "chr" prefix
@@ -562,14 +611,20 @@ pub fn read_reference_sequence(
         .collect();
 
     if !invalid_chars.is_empty() {
-        log(LogLevel::Warning, "Found invalid characters in reference sequence:");
+        log(
+            LogLevel::Warning,
+            "Found invalid characters in reference sequence:",
+        );
         for (pos, ch) in invalid_chars {
-            log(LogLevel::Warning, &format!(
-                "Position {}: '{}' (ASCII: {})",
-                pos,
-                String::from_utf8_lossy(&[ch]),
-                ch
-            ));
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "Position {}: '{}' (ASCII: {})",
+                    pos,
+                    String::from_utf8_lossy(&[ch]),
+                    ch
+                ),
+            );
         }
         return Err(VcfError::Parse(format!(
             "Invalid nucleotides found in sequence for region {}:{}-{}",
@@ -577,10 +632,16 @@ pub fn read_reference_sequence(
         )));
     }
 
-    log(LogLevel::Info, &format!(
-        "Completed reading reference sequence: {}bp for chr{}:{}-{}", 
-        sequence.len(), chr, clamped_start, clamped_end
-    ));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Completed reading reference sequence: {}bp for chr{}:{}-{}",
+            sequence.len(),
+            chr,
+            clamped_start,
+            clamped_end
+        ),
+    );
 
     Ok(sequence)
 }
@@ -588,300 +649,345 @@ pub fn read_reference_sequence(
 // Helper function to parse GTF file and extract best CDS regions for each gene
 // GTF and GFF use 1-based coordinate system
 // Returns one TranscriptAnnotationCDS per gene (the best transcript according to priority rules)
-pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnotationCDS>, VcfError> {
-   set_stage(ProcessingStage::Global);
-   log(LogLevel::Info, &format!("Parsing GTF file for chromosome: {}", chr));
-   
-   init_step_progress(&format!("Parsing GTF file for chr{}", chr), 3);
-   
-   // Open the GTF file.
-   let file = File::open(gtf_path).map_err(|e| {
-       let error_msg = format!("GTF file not found: {:?}", e);
-       log(LogLevel::Error, &error_msg);
-       VcfError::Io(io::Error::new(
-           io::ErrorKind::NotFound,
-           error_msg,
-       ))
-   })?;
-   let reader = BufReader::new(file);
+pub fn parse_gtf_file(
+    gtf_path: &Path,
+    chr: &str,
+) -> Result<Vec<TranscriptAnnotationCDS>, VcfError> {
+    set_stage(ProcessingStage::Global);
+    log(
+        LogLevel::Info,
+        &format!("Parsing GTF file for chromosome: {}", chr),
+    );
 
-   // Define priority order for transcript tags
-   // Lower index = higher priority
-   const PRIORITY_TAGS: [&str; 7] = [
-       "MANE_Select",
-       "MANE_Plus_Clinical",
-       "CCDS",
-       "appris_principal_1",
-       "GENCODE_Primary",
-       "Ensembl_canonical",
-       "basic",
-   ];
+    init_step_progress(&format!("Parsing GTF file for chr{}", chr), 3);
 
-   // Structure to hold transcript information for selection
-   #[derive(Default)]
-   struct TranscriptInfo {
-       segments: Vec<(i64, i64, char, i64)>, // start, end, strand, frame
-       priority_level: usize,                // Lower is higher priority (usize::MAX = no priority tag)
-       cds_length: i64,                      // Total length of all CDS segments
-       gene_id: String,                      // Gene this transcript belongs to
-       gene_name: Option<String>,            // Optional gene name
-   }
+    // Open the GTF file.
+    let file = File::open(gtf_path).map_err(|e| {
+        let error_msg = format!("GTF file not found: {:?}", e);
+        log(LogLevel::Error, &error_msg);
+        VcfError::Io(io::Error::new(io::ErrorKind::NotFound, error_msg))
+    })?;
+    let reader = BufReader::new(file);
 
-   // Map of transcript_id -> transcript info
-   let mut transcript_info_map: HashMap<String, TranscriptInfo> = HashMap::new();
-   
-   // Track statistics for logging
-   let mut skipped_lines = 0;
-   let mut processed_lines = 0;
-   let mut transcripts_found = HashSet::new();
-   let mut genes_found = HashSet::new();
-   let mut malformed_attributes = 0;
+    // Define priority order for transcript tags
+    // Lower index = higher priority
+    const PRIORITY_TAGS: [&str; 7] = [
+        "MANE_Select",
+        "MANE_Plus_Clinical",
+        "CCDS",
+        "appris_principal_1",
+        "GENCODE_Primary",
+        "Ensembl_canonical",
+        "basic",
+    ];
 
-   update_step_progress(0, &format!("Reading GTF entries for chr{}", chr));
-   log(LogLevel::Info, "Starting to read GTF entries");
+    // Structure to hold transcript information for selection
+    #[derive(Default)]
+    struct TranscriptInfo {
+        segments: Vec<(i64, i64, char, i64)>, // start, end, strand, frame
+        priority_level: usize, // Lower is higher priority (usize::MAX = no priority tag)
+        cds_length: i64,       // Total length of all CDS segments
+        gene_id: String,       // Gene this transcript belongs to
+        gene_name: Option<String>, // Optional gene name
+    }
 
-   // Read each line, parse if CDS, and store in transcript_info_map
-   for (line_num, line_result) in reader.lines().enumerate() {
-       let line = line_result?;
-       if line.starts_with('#') {
-           continue;
-       }
+    // Map of transcript_id -> transcript info
+    let mut transcript_info_map: HashMap<String, TranscriptInfo> = HashMap::new();
 
-       let fields: Vec<&str> = line.split('\t').collect();
-       if fields.len() < 9 {
-           skipped_lines += 1;
-           continue;
-       }
+    // Track statistics for logging
+    let mut skipped_lines = 0;
+    let mut processed_lines = 0;
+    let mut transcripts_found = HashSet::new();
+    let mut genes_found = HashSet::new();
+    let mut malformed_attributes = 0;
 
-       let seqname = fields[0].trim().trim_start_matches("chr");
-       if seqname != chr.trim_start_matches("chr") {
-           continue;
-       }
+    update_step_progress(0, &format!("Reading GTF entries for chr{}", chr));
+    log(LogLevel::Info, "Starting to read GTF entries");
 
-       // Only process CDS features.
-       if fields[2] != "CDS" {
-           continue;
-       }
+    // Read each line, parse if CDS, and store in transcript_info_map
+    for (line_num, line_result) in reader.lines().enumerate() {
+        let line = line_result?;
+        if line.starts_with('#') {
+            continue;
+        }
 
-       processed_lines += 1;
-       if processed_lines % 10000 == 0 {
-           update_step_progress(0, &format!("Processed {} CDS entries for chr{}", processed_lines, chr));
-           log(LogLevel::Info, &format!("Processed {} CDS entries", processed_lines));
-       }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 9 {
+            skipped_lines += 1;
+            continue;
+        }
 
-       let start: i64 = match fields[3].parse() {
-           Ok(s) => s,
-           Err(_) => {
-               eprintln!(
-                   "Warning: Invalid start position at line {}, skipping",
-                   line_num + 1
-               );
-               skipped_lines += 1;
-               continue;
-           }
-       };
+        let seqname = fields[0].trim().trim_start_matches("chr");
+        if seqname != chr.trim_start_matches("chr") {
+            continue;
+        }
 
-       let end: i64 = match fields[4].parse() {
-           Ok(e) => e,
-           Err(_) => {
-               eprintln!(
-                   "Warning: Invalid end position at line {}, skipping",
-                   line_num + 1
-               );
-               skipped_lines += 1;
-               continue;
-           }
-       };
+        // Only process CDS features.
+        if fields[2] != "CDS" {
+            continue;
+        }
 
-       let strand_char = fields[6].chars().next().unwrap_or('.');
-       let frame: i64 = fields[7].parse().unwrap_or_else(|_| {
-           eprintln!("Warning: Invalid frame at line {}, using 0", line_num + 1);
-           0
-       });
+        processed_lines += 1;
+        if processed_lines % 10000 == 0 {
+            update_step_progress(
+                0,
+                &format!("Processed {} CDS entries for chr{}", processed_lines, chr),
+            );
+            log(
+                LogLevel::Info,
+                &format!("Processed {} CDS entries", processed_lines),
+            );
+        }
 
-       // Parse attributes to find transcript_id, gene_id, gene_name, and priority tags
-       let attributes = fields[8];
-       let mut transcript_id = None;
-       let mut gene_id = None;
-       let mut gene_name = None;
-       let mut found_tags = Vec::new();
-       let mut gene_type = None;
-       let mut transcript_type = None;
+        let start: i64 = match fields[3].parse() {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!(
+                    "Warning: Invalid start position at line {}, skipping",
+                    line_num + 1
+                );
+                skipped_lines += 1;
+                continue;
+            }
+        };
 
-       for attr in attributes.split(';') {
-           let attr = attr.trim();
-           if attr.is_empty() {
-               continue;
-           }
+        let end: i64 = match fields[4].parse() {
+            Ok(e) => e,
+            Err(_) => {
+                eprintln!(
+                    "Warning: Invalid end position at line {}, skipping",
+                    line_num + 1
+                );
+                skipped_lines += 1;
+                continue;
+            }
+        };
 
-           let parts: Vec<&str> = if attr.contains('=') {
-               attr.splitn(2, '=').collect()
-           } else {
-               attr.splitn(2, ' ').collect()
-           };
+        let strand_char = fields[6].chars().next().unwrap_or('.');
+        let frame: i64 = fields[7].parse().unwrap_or_else(|_| {
+            eprintln!("Warning: Invalid frame at line {}, using 0", line_num + 1);
+            0
+        });
 
-           if parts.len() != 2 {
-               continue;
-           }
+        // Parse attributes to find transcript_id, gene_id, gene_name, and priority tags
+        let attributes = fields[8];
+        let mut transcript_id = None;
+        let mut gene_id = None;
+        let mut gene_name = None;
+        let mut found_tags = Vec::new();
+        let mut gene_type = None;
+        let mut transcript_type = None;
 
-           let key = parts[0].trim();
-           let value = parts[1].trim().trim_matches('"').trim_matches('\'');
+        for attr in attributes.split(';') {
+            let attr = attr.trim();
+            if attr.is_empty() {
+                continue;
+            }
 
-           match key {
-               "transcript_id" => transcript_id = Some(value.to_string()),
-               "gene_id" => gene_id = Some(value.to_string()),
-               "gene_name" => gene_name = Some(value.to_string()),
-               "gene_type" => gene_type = Some(value.to_string()),
-               "transcript_type" => transcript_type = Some(value.to_string()),
-               "tag" => found_tags.push(value.to_string()),
-               _ => {}
-           }
-       }
+            let parts: Vec<&str> = if attr.contains('=') {
+                attr.splitn(2, '=').collect()
+            } else {
+                attr.splitn(2, ' ').collect()
+            };
 
-       // Skip non-protein-coding features if we can determine type
-       if let Some(ref gt) = gene_type {
-           if gt != "protein_coding" {
-               continue;
-           }
-       }
-       if let Some(ref tt) = transcript_type {
-           if tt != "protein_coding" {
-               continue;
-           }
-       }
+            if parts.len() != 2 {
+                continue;
+            }
 
-       // Get transcript ID or skip if missing
-       let transcript_id = match transcript_id {
-           Some(id) => id,
-           None => {
-               malformed_attributes += 1;
-               if malformed_attributes <= 5 {
-                   log(LogLevel::Warning, &format!(
-                       "Could not find transcript_id in attributes at line {}: {}",
-                       line_num + 1,
-                       attributes
-                   ));
-               }
-               continue;
-           }
-       };
+            let key = parts[0].trim();
+            let value = parts[1].trim().trim_matches('"').trim_matches('\'');
 
-       // Get gene ID or skip if missing
-       let gene_id = match gene_id {
-           Some(id) => id,
-           None => {
-               malformed_attributes += 1;
-               if malformed_attributes <= 5 {
-                   log(LogLevel::Warning, &format!(
-                       "Could not find gene_id in attributes at line {}: {}",
-                       line_num + 1,
-                       attributes
-                   ));
-               }
-               continue;
-           }
-       };
+            match key {
+                "transcript_id" => transcript_id = Some(value.to_string()),
+                "gene_id" => gene_id = Some(value.to_string()),
+                "gene_name" => gene_name = Some(value.to_string()),
+                "gene_type" => gene_type = Some(value.to_string()),
+                "transcript_type" => transcript_type = Some(value.to_string()),
+                "tag" => found_tags.push(value.to_string()),
+                _ => {}
+            }
+        }
 
-       // Track stats
-       genes_found.insert(gene_id.clone());
-       if let Some(ref gene) = gene_name {
-           transcripts_found.insert(format!("{}:{}", gene, transcript_id));
-       } else {
-           transcripts_found.insert(transcript_id.clone());
-       }
+        // Skip non-protein-coding features if we can determine type
+        if let Some(ref gt) = gene_type {
+            if gt != "protein_coding" {
+                continue;
+            }
+        }
+        if let Some(ref tt) = transcript_type {
+            if tt != "protein_coding" {
+                continue;
+            }
+        }
 
-       // Calculate CDS segment length
-       let segment_length = end - start + 1;
-       
-       // Determine priority level based on tags
-       let priority_level = found_tags.iter()
-           .filter_map(|tag| PRIORITY_TAGS.iter().position(|&p| p == tag))
-           .min()
-           .unwrap_or(usize::MAX); // Use MAX value if no priority tag found
+        // Get transcript ID or skip if missing
+        let transcript_id = match transcript_id {
+            Some(id) => id,
+            None => {
+                malformed_attributes += 1;
+                if malformed_attributes <= 5 {
+                    log(
+                        LogLevel::Warning,
+                        &format!(
+                            "Could not find transcript_id in attributes at line {}: {}",
+                            line_num + 1,
+                            attributes
+                        ),
+                    );
+                }
+                continue;
+            }
+        };
 
-       // Get existing transcript info or create a new one
-       let transcript_info = transcript_info_map.entry(transcript_id.clone()).or_insert_with(|| {
-           TranscriptInfo {
-               segments: Vec::new(),
-               priority_level,
-               cds_length: 0,
-               gene_id: gene_id.clone(),
-               gene_name: gene_name.clone(),
-           }
-       });
+        // Get gene ID or skip if missing
+        let gene_id = match gene_id {
+            Some(id) => id,
+            None => {
+                malformed_attributes += 1;
+                if malformed_attributes <= 5 {
+                    log(
+                        LogLevel::Warning,
+                        &format!(
+                            "Could not find gene_id in attributes at line {}: {}",
+                            line_num + 1,
+                            attributes
+                        ),
+                    );
+                }
+                continue;
+            }
+        };
 
-       // Update the transcript info
-       transcript_info.segments.push((start, end, strand_char, frame));
-       transcript_info.cds_length += segment_length;
-       
-       // Update priority level if we found a better one
-       if priority_level < transcript_info.priority_level {
-           transcript_info.priority_level = priority_level;
-       }
+        // Track stats
+        genes_found.insert(gene_id.clone());
+        if let Some(ref gene) = gene_name {
+            transcripts_found.insert(format!("{}:{}", gene, transcript_id));
+        } else {
+            transcripts_found.insert(transcript_id.clone());
+        }
 
-       // Make sure gene_id is consistent (should be the same for all segments of a transcript)
-       if transcript_info.gene_id != gene_id {
-           log(LogLevel::Warning, &format!(
-               "Inconsistent gene_id for transcript {} at line {}: {} vs {}",
-               transcript_id, line_num + 1, transcript_info.gene_id, gene_id
-           ));
-           // Keep the first gene_id we encountered
-       }
+        // Calculate CDS segment length
+        let segment_length = end - start + 1;
 
-       // Set gene_name if we didn't have it before
-       if transcript_info.gene_name.is_none() && gene_name.is_some() {
-           transcript_info.gene_name = gene_name;
-       }
-   }
+        // Determine priority level based on tags
+        let priority_level = found_tags
+            .iter()
+            .filter_map(|tag| PRIORITY_TAGS.iter().position(|&p| p == tag))
+            .min()
+            .unwrap_or(usize::MAX); // Use MAX value if no priority tag found
 
-   // Print summary of how many lines, transcripts, genes, etc.
-   update_step_progress(1, "Building transcript database");
-   log(LogLevel::Info, "Finished reading GTF file");
-   log(LogLevel::Info, &format!("Total CDS entries processed: {}", processed_lines));
-   log(LogLevel::Info, &format!("Skipped lines: {}", skipped_lines));
-   log(LogLevel::Info, &format!("Unique transcripts found: {}", transcripts_found.len()));
-   log(LogLevel::Info, &format!("Unique genes found: {}", genes_found.len()));
-   if malformed_attributes > 0 {
-       log(LogLevel::Warning, &format!(
-           "Entries with missing required attributes: {}",
-           malformed_attributes
-       ));
-   }
+        // Get existing transcript info or create a new one
+        let transcript_info = transcript_info_map
+            .entry(transcript_id.clone())
+            .or_insert_with(|| TranscriptInfo {
+                segments: Vec::new(),
+                priority_level,
+                cds_length: 0,
+                gene_id: gene_id.clone(),
+                gene_name: gene_name.clone(),
+            });
 
-   // Group transcripts by gene_id
-   let mut gene_to_transcripts: HashMap<String, Vec<String>> = HashMap::new();
-   for (transcript_id, info) in &transcript_info_map {
-       gene_to_transcripts
-           .entry(info.gene_id.clone())
-           .or_default()
-           .push(transcript_id.clone());
-   }
+        // Update the transcript info
+        transcript_info
+            .segments
+            .push((start, end, strand_char, frame));
+        transcript_info.cds_length += segment_length;
 
-   log(LogLevel::Info, "Starting to select best transcript for each gene");
-   
+        // Update priority level if we found a better one
+        if priority_level < transcript_info.priority_level {
+            transcript_info.priority_level = priority_level;
+        }
+
+        // Make sure gene_id is consistent (should be the same for all segments of a transcript)
+        if transcript_info.gene_id != gene_id {
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "Inconsistent gene_id for transcript {} at line {}: {} vs {}",
+                    transcript_id,
+                    line_num + 1,
+                    transcript_info.gene_id,
+                    gene_id
+                ),
+            );
+            // Keep the first gene_id we encountered
+        }
+
+        // Set gene_name if we didn't have it before
+        if transcript_info.gene_name.is_none() && gene_name.is_some() {
+            transcript_info.gene_name = gene_name;
+        }
+    }
+
+    // Print summary of how many lines, transcripts, genes, etc.
+    update_step_progress(1, "Building transcript database");
+    log(LogLevel::Info, "Finished reading GTF file");
+    log(
+        LogLevel::Info,
+        &format!("Total CDS entries processed: {}", processed_lines),
+    );
+    log(LogLevel::Info, &format!("Skipped lines: {}", skipped_lines));
+    log(
+        LogLevel::Info,
+        &format!("Unique transcripts found: {}", transcripts_found.len()),
+    );
+    log(
+        LogLevel::Info,
+        &format!("Unique genes found: {}", genes_found.len()),
+    );
+    if malformed_attributes > 0 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Entries with missing required attributes: {}",
+                malformed_attributes
+            ),
+        );
+    }
+
+    // Group transcripts by gene_id
+    let mut gene_to_transcripts: HashMap<String, Vec<String>> = HashMap::new();
+    for (transcript_id, info) in &transcript_info_map {
+        gene_to_transcripts
+            .entry(info.gene_id.clone())
+            .or_default()
+            .push(transcript_id.clone());
+    }
+
+    log(
+        LogLevel::Info,
+        "Starting to select best transcript for each gene",
+    );
+
     // For each gene, select the best transcript based on priority rules
     let mut best_transcripts = HashSet::new();
     for (gene_id, transcript_ids) in gene_to_transcripts {
-        log(LogLevel::Debug, &format!("Selecting best transcript for gene: {}", gene_id));
+        log(
+            LogLevel::Debug,
+            &format!("Selecting best transcript for gene: {}", gene_id),
+        );
         if transcript_ids.is_empty() {
             continue;
         }
 
-       // Find transcript with highest priority (lowest priority_level)
-       let min_priority = transcript_ids.iter()
-           .filter_map(|tid| transcript_info_map.get(tid))
-           .map(|info| info.priority_level)
-           .min()
-           .unwrap_or(usize::MAX);
+        // Find transcript with highest priority (lowest priority_level)
+        let min_priority = transcript_ids
+            .iter()
+            .filter_map(|tid| transcript_info_map.get(tid))
+            .map(|info| info.priority_level)
+            .min()
+            .unwrap_or(usize::MAX);
 
-       // Get all transcripts with this priority level
-       let candidates: Vec<&String> = transcript_ids.iter()
-           .filter(|tid| {
-               transcript_info_map.get(*tid)
-                   .map(|info| info.priority_level == min_priority)
-                   .unwrap_or(false)
-           })
-           .collect();
+        // Get all transcripts with this priority level
+        let candidates: Vec<&String> = transcript_ids
+            .iter()
+            .filter(|tid| {
+                transcript_info_map
+                    .get(*tid)
+                    .map(|info| info.priority_level == min_priority)
+                    .unwrap_or(false)
+            })
+            .collect();
 
         // When multiple transcripts have the same priority,
         // choose the one with the longest coding sequence length.
@@ -891,7 +997,8 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
             candidates[0].clone()
         } else {
             // For multiple candidates, find the longest CDS length among them.
-            let max_length = candidates.iter()
+            let max_length = candidates
+                .iter()
                 // Loop through each transcript ID in the candidates list.
                 .filter_map(|tid| transcript_info_map.get(*tid))
                 // For each ID, look it up in the transcript_info_map to get its details.
@@ -901,70 +1008,77 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
                 .max()
                 // Find the biggest CDS length in the list.
                 .unwrap_or(0);
-                // If something goes wrong and we get no lengths (shouldn’t happen), use 0 as a fallback.
-        
+            // If something goes wrong and we get no lengths (shouldn’t happen), use 0 as a fallback.
+
             // Now, collect all transcript IDs that have this maximum CDS length.
-            let longest_candidates: Vec<&&String> = candidates.iter()
+            let longest_candidates: Vec<&&String> = candidates
+                .iter()
                 // Iterate over references to transcript IDs in candidates.
                 .filter(|tid| {
                     // For each transcript ID reference
-                    transcript_info_map.get(&tid[..])
-                    // Look up its details in the transcript_info_map using a string slice.
-                    .map(|info| info.cds_length == max_length)
-                    // Check if its CDS length matches the maximum found earlier.
-                    .unwrap_or(false)
+                    transcript_info_map
+                        .get(&tid[..])
+                        // Look up its details in the transcript_info_map using a string slice.
+                        .map(|info| info.cds_length == max_length)
+                        // Check if its CDS length matches the maximum found earlier.
+                        .unwrap_or(false)
                     // Return false if the transcript isn’t found in the map.
                 })
                 .collect();
-                // Gather all matching transcript IDs into a vector.
-        
+            // Gather all matching transcript IDs into a vector.
+
             // Pick the best one from the transcripts with the longest CDS.
             // If there’s more than one with the same max length, take the first.
-            longest_candidates.first()
+            longest_candidates
+                .first()
                 // Retrieve the first reference to a transcript ID from longest_candidates.
                 .map(|s| (**s).clone())
                 // Dereference twice to get the String and clone it for the result.
                 .unwrap_or_else(|| candidates[0].clone())
-                // If no longest candidate exists, use the first candidate as a fallback.
+            // If no longest candidate exists, use the first candidate as a fallback.
         };
 
-       best_transcripts.insert(best_transcript);
-   }
+        best_transcripts.insert(best_transcript);
+    }
 
-    log(LogLevel::Info, &format!(
-      "Selected {} best transcripts out of {} total transcripts",
-      best_transcripts.len(), transcript_info_map.len()
-   ));
-   update_step_progress(2, "Building transcript data structures");
+    log(
+        LogLevel::Info,
+        &format!(
+            "Selected {} best transcripts out of {} total transcripts",
+            best_transcripts.len(),
+            transcript_info_map.len()
+        ),
+    );
+    update_step_progress(2, "Building transcript data structures");
 
-   // Now build a vector of TranscriptAnnotationCDS objects, but only for the best transcripts
-   let mut transcripts_vec = Vec::new();
+    // Now build a vector of TranscriptAnnotationCDS objects, but only for the best transcripts
+    let mut transcripts_vec = Vec::new();
 
-   for (tid, info) in transcript_info_map {
-       // Skip if this transcript is not the best for its gene
-       if !best_transcripts.contains(&tid) {
-           continue;
-       }
+    for (tid, info) in transcript_info_map {
+        // Skip if this transcript is not the best for its gene
+        if !best_transcripts.contains(&tid) {
+            continue;
+        }
 
-       // Process segments
-       let mut segments = info.segments;
-       segments.sort_by_key(|&(s, _, _, _)| s);
+        // Process segments
+        let mut segments = info.segments;
+        segments.sort_by_key(|&(s, _, _, _)| s);
 
-       if segments.is_empty() {
-           continue;
-       }
+        if segments.is_empty() {
+            continue;
+        }
 
-       let strand = segments[0].2;
-       if strand == '-' {
-           segments.reverse();
-       }
+        let strand = segments[0].2;
+        if strand == '-' {
+            segments.reverse();
+        }
 
-       let strand_char = segments[0].2;
-       let frames_vec: Vec<i64> = segments.iter().map(|&(_s, _e, _str, f)| f).collect();
-       let seg_intervals: Vec<ZeroBasedHalfOpen> = segments
-           .iter()
-           .map(|&(s, e, _, _)| ZeroBasedHalfOpen::from_1based_inclusive(s, e))
-           .collect();
+        let strand_char = segments[0].2;
+        let frames_vec: Vec<i64> = segments.iter().map(|&(_s, _e, _str, f)| f).collect();
+        let seg_intervals: Vec<ZeroBasedHalfOpen> = segments
+            .iter()
+            .map(|&(s, e, _, _)| ZeroBasedHalfOpen::from_1based_inclusive(s, e))
+            .collect();
 
         transcripts_vec.push(TranscriptAnnotationCDS {
             transcript_id: tid,
@@ -974,21 +1088,28 @@ pub fn parse_gtf_file(gtf_path: &Path, chr: &str) -> Result<Vec<TranscriptAnnota
             frames: frames_vec,
             segments: seg_intervals,
         });
-   }
+    }
 
-    log(LogLevel::Info, &format!(
-       "Number of best transcripts returned: {}",
-       transcripts_vec.len()
-   ));
-   if transcripts_vec.is_empty() {
-       log(LogLevel::Warning, &format!("No CDS transcripts parsed for chromosome {}", chr));
-   }
-   
-   finish_step_progress(&format!(
-       "Parsed {} transcripts for chr{}", 
-       transcripts_vec.len(), chr
-   ));
+    log(
+        LogLevel::Info,
+        &format!(
+            "Number of best transcripts returned: {}",
+            transcripts_vec.len()
+        ),
+    );
+    if transcripts_vec.is_empty() {
+        log(
+            LogLevel::Warning,
+            &format!("No CDS transcripts parsed for chromosome {}", chr),
+        );
+    }
 
-   // Return only the best transcript for each gene
-   Ok(transcripts_vec)
+    finish_step_progress(&format!(
+        "Parsed {} transcripts for chr{}",
+        transcripts_vec.len(),
+        chr
+    ));
+
+    // Return only the best transcript for each gene
+    Ok(transcripts_vec)
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -241,6 +241,82 @@ pub struct PopulationContext<'a> {
     /// The effective sequence length (L) for normalization in diversity calculations.
     /// This should account for any masking or specific intervals considered.
     pub sequence_length: i64,
+    pub dense_genotypes: Option<&'a DenseGenotypeMatrix>,
+    pub dense_summary: Option<Arc<DensePopulationSummary>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DenseGenotypeMatrix {
+    data: Arc<[u8]>,
+    missing: Option<Arc<[u64]>>,
+    variant_count: usize,
+    sample_count: usize,
+    ploidy: usize,
+    stride: usize,
+    max_allele: u8,
+}
+
+impl DenseGenotypeMatrix {
+    pub fn new(
+        data: Vec<u8>,
+        missing: Option<Vec<u64>>,
+        variant_count: usize,
+        sample_count: usize,
+        ploidy: usize,
+        max_allele: u8,
+    ) -> Self {
+        debug_assert_eq!(
+            data.len(),
+            variant_count * sample_count * ploidy,
+            "dense genotype matrix requires variants * samples * ploidy entries",
+        );
+        let data = Arc::<[u8]>::from(data.into_boxed_slice());
+        let missing = missing.map(|bits| Arc::<[u64]>::from(bits.into_boxed_slice()));
+        Self {
+            data,
+            missing,
+            variant_count,
+            sample_count,
+            ploidy,
+            stride: sample_count * ploidy,
+            max_allele,
+        }
+    }
+
+    #[inline]
+    pub fn variant_count(&self) -> usize {
+        self.variant_count
+    }
+
+    #[inline]
+    pub fn sample_count(&self) -> usize {
+        self.sample_count
+    }
+
+    #[inline]
+    pub fn ploidy(&self) -> usize {
+        self.ploidy
+    }
+
+    #[inline]
+    fn stride(&self) -> usize {
+        self.stride
+    }
+
+    #[inline]
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    #[inline]
+    fn missing_slice(&self) -> Option<&[u64]> {
+        self.missing.as_deref()
+    }
+
+    #[inline]
+    pub fn max_allele(&self) -> u8 {
+        self.max_allele
+    }
 }
 
 /// Holds the result of a Dxy (between-population nucleotide diversity) calculation,
@@ -844,7 +920,7 @@ const INVALID_GROUP: u16 = u16::MAX;
 struct PairDescriptor {
     left: u16,
     right: u16,
-
+    key: String,
 }
 
 #[derive(Clone)]
@@ -857,7 +933,6 @@ struct SubpopulationMembership {
     /// regardless of which comparisons had sufficient data.
     pair_keys: Vec<PairDescriptor>,
 }
-
 
 impl SubpopulationMembership {
     fn from_map(sample_count: usize, map_subpop: &HashMap<(usize, HaplotypeSide), String>) -> Self {
@@ -994,6 +1069,403 @@ impl HapMembership {
         }
 
         Self { left, right, total }
+    }
+}
+
+#[derive(Clone)]
+struct DenseMembership {
+    offsets: Vec<usize>,
+}
+
+impl DenseMembership {
+    fn build(matrix: &DenseGenotypeMatrix, haplotypes: &[(usize, HaplotypeSide)]) -> Self {
+        let sample_count = matrix.sample_count();
+        let ploidy = matrix.ploidy();
+        let mut left = vec![false; sample_count];
+        let mut right = vec![false; sample_count];
+        let mut offsets = Vec::with_capacity(haplotypes.len());
+
+        for &(sample_idx, side) in haplotypes {
+            if sample_idx >= sample_count {
+                continue;
+            }
+            match side {
+                HaplotypeSide::Left => {
+                    if !left[sample_idx] {
+                        left[sample_idx] = true;
+                        offsets.push(sample_idx * ploidy);
+                    }
+                }
+                HaplotypeSide::Right => {
+                    if ploidy <= 1 {
+                        continue;
+                    }
+                    if !right[sample_idx] {
+                        right[sample_idx] = true;
+                        offsets.push(sample_idx * ploidy + 1);
+                    }
+                }
+            }
+        }
+
+        Self { offsets }
+    }
+
+    #[inline]
+    fn offsets(&self) -> &[usize] {
+        &self.offsets
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+}
+
+#[inline(always)]
+fn dense_missing(bits: &[u64], idx: usize) -> bool {
+    let word = idx >> 6;
+    let bit = idx & 63;
+    unsafe { ((*bits.get_unchecked(word) >> bit) & 1) == 1 }
+}
+
+#[derive(Debug)]
+pub struct DensePopulationSummary {
+    alt_counts: Arc<[u32]>,
+    called_counts: Arc<[u32]>,
+    haplotype_capacity: usize,
+}
+
+impl DensePopulationSummary {
+    #[inline]
+    pub fn alt_counts(&self) -> &[u32] {
+        &self.alt_counts
+    }
+
+    #[inline]
+    pub fn called_counts(&self) -> &[u32] {
+        &self.called_counts
+    }
+
+    #[inline]
+    pub fn haplotype_capacity(&self) -> usize {
+        self.haplotype_capacity
+    }
+}
+
+pub fn build_dense_population_summary(
+    matrix: &DenseGenotypeMatrix,
+    haplotypes: &[(usize, HaplotypeSide)],
+) -> DensePopulationSummary {
+    let membership = DenseMembership::build(matrix, haplotypes);
+    let offsets = membership.offsets();
+    let variant_count = matrix.variant_count();
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut alt_counts = vec![0u32; variant_count];
+    let mut called_counts = vec![0u32; variant_count];
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..variant_count {
+            let base = variant_idx * stride;
+            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            alt_counts[variant_idx] = alt as u32;
+            called_counts[variant_idx] = called as u32;
+        }
+    } else {
+        let total = offsets.len() as u32;
+        for variant_idx in 0..variant_count {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            alt_counts[variant_idx] = alt as u32;
+            called_counts[variant_idx] = total;
+        }
+    }
+
+    DensePopulationSummary {
+        alt_counts: Arc::from(alt_counts.into_boxed_slice()),
+        called_counts: Arc::from(called_counts.into_boxed_slice()),
+        haplotype_capacity: offsets.len(),
+    }
+}
+
+fn count_segregating_sites_from_summary(summary: &DensePopulationSummary) -> usize {
+    summary
+        .alt_counts()
+        .iter()
+        .zip(summary.called_counts())
+        .filter(|(&alt, &called)| {
+            let called = called as usize;
+            let alt = alt as usize;
+            called >= 2 && alt > 0 && alt < called
+        })
+        .count()
+}
+
+fn calculate_pi_from_summary(summary: &DensePopulationSummary, seq_length: i64) -> f64 {
+    calculate_pi_from_summary_with_precomputed(summary, seq_length, None)
+}
+
+fn calculate_pi_from_summary_with_precomputed(
+    summary: &DensePopulationSummary,
+    seq_length: i64,
+    precomputed: Option<f64>,
+) -> f64 {
+    if summary.haplotype_capacity() <= 1 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: insufficient haplotypes ({})",
+                summary.haplotype_capacity()
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length < 0 {
+        log(
+            LogLevel::Warning,
+            &format!("Cannot calculate pi: invalid sequence length ({seq_length})"),
+        );
+        return 0.0;
+    }
+
+    if seq_length == 0 {
+        log(
+            LogLevel::Warning,
+            "Cannot calculate pi: zero sequence length causes division by zero",
+        );
+        return f64::INFINITY;
+    }
+
+    let sum_pi = if let Some(value) = precomputed {
+        value
+    } else {
+        let mut sum = 0.0_f64;
+        for (&alt, &called) in summary.alt_counts().iter().zip(summary.called_counts()) {
+            let alt = alt as usize;
+            let called = called as usize;
+            if let Some(pi) = dense_pi_from_counts(called, alt) {
+                sum += pi;
+            }
+        }
+        sum
+    };
+
+    sum_pi / seq_length as f64
+}
+
+#[derive(Clone, Copy, Default)]
+struct HudsonSummaryTotals {
+    numerator_sum: f64,
+    denominator_sum: f64,
+    pi1_sum: f64,
+    pi2_sum: f64,
+    dxy_sum_all: f64,
+}
+
+fn aggregate_hudson_components_from_summaries(
+    pop1: &DensePopulationSummary,
+    pop2: &DensePopulationSummary,
+) -> HudsonSummaryTotals {
+    let len = pop1.alt_counts().len().min(pop2.alt_counts().len());
+    let alt1 = pop1.alt_counts();
+    let alt2 = pop2.alt_counts();
+    let called1 = pop1.called_counts();
+    let called2 = pop2.called_counts();
+    let mut totals = HudsonSummaryTotals::default();
+
+    for idx in 0..len {
+        let n1 = called1[idx] as usize;
+        let n2 = called2[idx] as usize;
+        if n1 == 0 || n2 == 0 {
+            continue;
+        }
+
+        let alt_count1 = alt1[idx] as usize;
+        let alt_count2 = alt2[idx] as usize;
+        let ref_count1 = n1 - alt_count1;
+        let ref_count2 = n2 - alt_count2;
+
+        let denom_pairs = (n1 * n2) as f64;
+        if denom_pairs == 0.0 {
+            continue;
+        }
+
+        let mut dxy = (alt_count1 * ref_count2 + ref_count1 * alt_count2) as f64 / denom_pairs;
+        if dxy < 0.0 {
+            dxy = 0.0;
+        } else if dxy > 1.0 {
+            dxy = 1.0;
+        }
+        totals.dxy_sum_all += dxy;
+
+        if n1 < 2 || n2 < 2 {
+            continue;
+        }
+
+        let denom1 = (n1 * (n1 - 1)) as f64;
+        let denom2 = (n2 * (n2 - 1)) as f64;
+        let pi1 = if denom1 > 0.0 {
+            2.0 * (alt_count1 as f64) * (ref_count1 as f64) / denom1
+        } else {
+            0.0
+        };
+        let pi2 = if denom2 > 0.0 {
+            2.0 * (alt_count2 as f64) * (ref_count2 as f64) / denom2
+        } else {
+            0.0
+        };
+
+        totals.pi1_sum += pi1;
+        totals.pi2_sum += pi2;
+
+        if dxy > FST_EPSILON {
+            totals.numerator_sum += dxy - 0.5 * (pi1 + pi2);
+            totals.denominator_sum += dxy;
+        } else {
+            let pi_avg = 0.5 * (pi1 + pi2);
+            if pi_avg.abs() <= FST_EPSILON {
+                // contributes zero to both sums
+            }
+        }
+    }
+
+    totals
+}
+
+fn hudson_component_sums(sites: &[SiteFstHudson]) -> (f64, f64) {
+    let mut num_sum = 0.0_f64;
+    let mut den_sum = 0.0_f64;
+    for s in sites {
+        if let (Some(nc), Some(dc)) = (s.num_component, s.den_component) {
+            num_sum += nc;
+            den_sum += dc;
+        }
+    }
+    (num_sum, den_sum)
+}
+
+fn dxy_from_summaries(
+    pop1: &DensePopulationSummary,
+    pop2: &DensePopulationSummary,
+    sequence_length: i64,
+) -> Option<f64> {
+    if sequence_length <= 0 {
+        return None;
+    }
+    let len = pop1.alt_counts().len().min(pop2.alt_counts().len());
+    let alt1 = pop1.alt_counts();
+    let alt2 = pop2.alt_counts();
+    let called1 = pop1.called_counts();
+    let called2 = pop2.called_counts();
+    let mut sum_dxy = 0.0_f64;
+
+    for idx in 0..len {
+        let n1 = called1[idx] as usize;
+        let alt_count1 = alt1[idx] as usize;
+        let n2 = called2[idx] as usize;
+        let alt_count2 = alt2[idx] as usize;
+        if let Some(dxy) = dense_dxy_from_biallelic_counts(n1, alt_count1, n2, alt_count2) {
+            sum_dxy += dxy;
+        }
+    }
+
+    Some(sum_dxy / sequence_length as f64)
+}
+
+#[inline(always)]
+fn dense_sum_alt_no_missing(data: &[u8], base: usize, offsets: &[usize]) -> usize {
+    let mut sum = 0usize;
+    unsafe {
+        let ptr = data.as_ptr().add(base);
+        for &offset in offsets {
+            sum += *ptr.add(offset) as usize;
+        }
+    }
+    sum
+}
+
+#[inline(always)]
+fn dense_sum_alt_with_missing(
+    data: &[u8],
+    base: usize,
+    offsets: &[usize],
+    bits: &[u64],
+) -> (usize, usize) {
+    let mut alt = 0usize;
+    let mut total = 0usize;
+    unsafe {
+        let ptr = data.as_ptr().add(base);
+        for &offset in offsets {
+            let idx = base + offset;
+            if dense_missing(bits, idx) {
+                continue;
+            }
+            alt += *ptr.add(offset) as usize;
+            total += 1;
+        }
+    }
+    (total, alt)
+}
+
+#[inline(always)]
+fn dense_pi_from_counts(total_called: usize, alt_count: usize) -> Option<f64> {
+    if total_called < 2 {
+        return None;
+    }
+    let n = total_called as f64;
+    let alt = alt_count as f64;
+    let ref_count = (total_called - alt_count) as f64;
+    let sum_sq = ref_count * ref_count + alt * alt;
+    Some(n / (n - 1.0) * (1.0 - sum_sq / (n * n)))
+}
+
+#[inline(always)]
+fn dense_dxy_from_biallelic_counts(n1: usize, alt1: usize, n2: usize, alt2: usize) -> Option<f64> {
+    if n1 == 0 || n2 == 0 {
+        return None;
+    }
+    let n1_f = n1 as f64;
+    let n2_f = n2 as f64;
+    let alt1_f = alt1 as f64 / n1_f;
+    let alt2_f = alt2 as f64 / n2_f;
+    let ref1 = 1.0 - alt1_f;
+    let ref2 = 1.0 - alt2_f;
+    let mut dot = ref1 * ref2 + alt1_f * alt2_f;
+    if dot < 0.0 {
+        dot = 0.0;
+    }
+    let mut dxy = 1.0 - dot;
+    if dxy < 0.0 {
+        dxy = 0.0;
+    } else if dxy > 1.0 {
+        dxy = 1.0;
+    }
+    Some(dxy)
+}
+
+#[inline(always)]
+fn dense_fst_components_from_biallelic(
+    dxy: Option<f64>,
+    pi1: Option<f64>,
+    pi2: Option<f64>,
+) -> (Option<f64>, Option<f64>, Option<f64>) {
+    match (dxy, pi1, pi2) {
+        (Some(d), Some(p1), Some(p2)) => {
+            if d > FST_EPSILON {
+                let num = d - 0.5 * (p1 + p2);
+                (Some(num / d), Some(num), Some(d))
+            } else {
+                let pi_avg = 0.5 * (p1 + p2);
+                if pi_avg.abs() <= FST_EPSILON {
+                    (Some(0.0), Some(0.0), Some(0.0))
+                } else {
+                    (None, None, None)
+                }
+            }
+        }
+        _ => (None, None, None),
     }
 }
 
@@ -1198,7 +1670,6 @@ fn calculate_fst_wc_at_site_with_membership(
 
     workspace.stats.clear();
 
-
     (
         overall_fst_at_site,
         pairwise_fst_estimate_map,
@@ -1207,7 +1678,6 @@ fn calculate_fst_wc_at_site_with_membership(
         pairwise_variance_components_map,
     )
 }
-
 
 fn calculate_variance_components(
     pop_stats: &[PopSiteStat], // (n_i, p_i)
@@ -1612,6 +2082,30 @@ pub fn calculate_d_xy_hudson<'a>(
         return Ok(DxyHudsonResult { d_xy: None });
     }
 
+    if let (Some(summary1), Some(summary2)) = (
+        pop1_context.dense_summary.as_deref(),
+        pop2_context.dense_summary.as_deref(),
+    ) {
+        let dxy_value = dxy_from_summaries(summary1, summary2, pop1_context.sequence_length);
+        return Ok(DxyHudsonResult { d_xy: dxy_value });
+    }
+
+    if let (Some(matrix1), Some(matrix2)) =
+        (pop1_context.dense_genotypes, pop2_context.dense_genotypes)
+    {
+        if std::ptr::eq(matrix1, matrix2) && matrix1.ploidy() == 2 {
+            let membership1 = DenseMembership::build(matrix1, &pop1_context.haplotypes);
+            let membership2 = DenseMembership::build(matrix2, &pop2_context.haplotypes);
+            let d_xy_value = calculate_dxy_dense(
+                matrix1,
+                &membership1,
+                &membership2,
+                pop1_context.sequence_length,
+            );
+            return Ok(DxyHudsonResult { d_xy: d_xy_value });
+        }
+    }
+
     // Use unbiased per-site aggregation approach
     let mut sum_dxy = 0.0;
     let mut variant_count = 0;
@@ -1657,6 +2151,79 @@ pub fn calculate_d_xy_hudson<'a>(
     };
 
     Ok(DxyHudsonResult { d_xy: d_xy_value })
+}
+
+fn calculate_dxy_dense(
+    matrix: &DenseGenotypeMatrix,
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+    sequence_length: i64,
+) -> Option<f64> {
+    if pop1_mem.len() == 0 || pop2_mem.len() == 0 {
+        return None;
+    }
+    if sequence_length <= 0 {
+        return None;
+    }
+
+    let mut counts1 = vec![0u32; 256];
+    let mut used1 = Vec::with_capacity(8);
+    let mut counts2 = vec![0u32; 256];
+    let mut used2 = Vec::with_capacity(8);
+    let mut sum_dxy = 0.0_f64;
+
+    for variant_idx in 0..matrix.variant_count() {
+        let (n1, _) = dense_collect_counts(matrix, pop1_mem, variant_idx, &mut counts1, &mut used1);
+        let (n2, _) = dense_collect_counts(matrix, pop2_mem, variant_idx, &mut counts2, &mut used2);
+
+        if n1 == 0 || n2 == 0 {
+            dense_reset_counts(&mut counts1, &mut used1);
+            dense_reset_counts(&mut counts2, &mut used2);
+            continue;
+        }
+
+        let inv1 = 1.0 / n1 as f64;
+        let inv2 = 1.0 / n2 as f64;
+        let mut dot = 0.0_f64;
+        if used1.len() <= used2.len() {
+            for &allele in &used1 {
+                let c1 = counts1[allele];
+                if c1 == 0 {
+                    continue;
+                }
+                let c2 = if allele < counts2.len() {
+                    counts2[allele]
+                } else {
+                    0
+                };
+                if c2 != 0 {
+                    dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                }
+            }
+        } else {
+            for &allele in &used2 {
+                let c2 = counts2[allele];
+                if c2 == 0 {
+                    continue;
+                }
+                let c1 = if allele < counts1.len() {
+                    counts1[allele]
+                } else {
+                    0
+                };
+                if c1 != 0 {
+                    dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                }
+            }
+        }
+        let dxy_site = (1.0 - dot).max(0.0).min(1.0);
+        sum_dxy += dxy_site;
+
+        dense_reset_counts(&mut counts1, &mut used1);
+        dense_reset_counts(&mut counts2, &mut used2);
+    }
+
+    Some(sum_dxy / sequence_length as f64)
 }
 
 /// Extract allele counts for a population at a specific variant site.
@@ -1870,6 +2437,72 @@ fn compute_pi_metrics_fast(
     }
 }
 
+fn dense_collect_counts(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    variant_idx: usize,
+    counts: &mut Vec<u32>,
+    used: &mut Vec<usize>,
+) -> (usize, f64) {
+    let stride = matrix.stride();
+    let base = variant_idx * stride;
+    let data = matrix.data();
+    let offsets = membership.offsets();
+    let total_called = if let Some(bits) = matrix.missing_slice() {
+        let mut called = 0usize;
+        unsafe {
+            let ptr = data.as_ptr();
+            for &offset in offsets {
+                let idx = base + offset;
+                if dense_missing(bits, idx) {
+                    continue;
+                }
+                let allele = *ptr.add(idx) as usize;
+                if allele >= counts.len() {
+                    counts.resize(allele + 1, 0);
+                }
+                if counts[allele] == 0 {
+                    used.push(allele);
+                }
+                counts[allele] += 1;
+                called += 1;
+            }
+        }
+        called
+    } else {
+        unsafe {
+            let ptr = data.as_ptr();
+            for &offset in offsets {
+                let idx = base + offset;
+                let allele = *ptr.add(idx) as usize;
+                if allele >= counts.len() {
+                    counts.resize(allele + 1, 0);
+                }
+                if counts[allele] == 0 {
+                    used.push(allele);
+                }
+                counts[allele] += 1;
+            }
+        }
+        offsets.len()
+    };
+
+    let mut sum_counts_sq = 0.0;
+    for &allele in used.iter() {
+        let count = counts[allele] as f64;
+        sum_counts_sq += count * count;
+    }
+
+    (total_called, sum_counts_sq)
+}
+
+fn dense_reset_counts(counts: &mut Vec<u32>, used: &mut Vec<usize>) {
+    for &idx in used.iter() {
+        counts[idx] = 0;
+    }
+    used.clear();
+}
+
 /// Compute between-population diversity (D_xy) from allele counts.
 ///
 /// Mathematical Foundation:
@@ -2066,6 +2699,226 @@ pub fn calculate_hudson_fst_per_site(
     sites
 }
 
+fn dense_hudson_sites(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    if matrix.max_allele() <= 1 {
+        return dense_hudson_sites_biallelic(matrix, variants, pop1_mem, pop2_mem);
+    }
+    dense_hudson_sites_general(matrix, variants, pop1_mem, pop2_mem)
+}
+
+fn dense_hudson_sites_general(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    let mut counts1 = vec![0u32; 256];
+    let mut used1 = Vec::with_capacity(8);
+    let mut counts2 = vec![0u32; 256];
+    let mut used2 = Vec::with_capacity(8);
+    let mut sites = Vec::with_capacity(variants.len());
+
+    for (variant_idx, variant) in variants.iter().enumerate() {
+        let (n1, sum_sq1) =
+            dense_collect_counts(matrix, pop1_mem, variant_idx, &mut counts1, &mut used1);
+        let (n2, sum_sq2) =
+            dense_collect_counts(matrix, pop2_mem, variant_idx, &mut counts2, &mut used2);
+
+        let pi1 = if n1 >= 2 {
+            let n = n1 as f64;
+            Some(n / (n - 1.0) * (1.0 - sum_sq1 / (n * n)))
+        } else {
+            None
+        };
+        let pi2 = if n2 >= 2 {
+            let n = n2 as f64;
+            Some(n / (n - 1.0) * (1.0 - sum_sq2 / (n * n)))
+        } else {
+            None
+        };
+
+        let dxy = if n1 == 0 || n2 == 0 {
+            None
+        } else {
+            let inv1 = 1.0 / n1 as f64;
+            let inv2 = 1.0 / n2 as f64;
+            let mut dot = 0.0_f64;
+            if used1.len() <= used2.len() {
+                for &allele in &used1 {
+                    let c1 = counts1[allele];
+                    if c1 == 0 {
+                        continue;
+                    }
+                    let c2 = if allele < counts2.len() {
+                        counts2[allele]
+                    } else {
+                        0
+                    };
+                    if c2 != 0 {
+                        dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                    }
+                }
+            } else {
+                for &allele in &used2 {
+                    let c2 = counts2[allele];
+                    if c2 == 0 {
+                        continue;
+                    }
+                    let c1 = if allele < counts1.len() {
+                        counts1[allele]
+                    } else {
+                        0
+                    };
+                    if c1 != 0 {
+                        dot += (c1 as f64 * inv1) * (c2 as f64 * inv2);
+                    }
+                }
+            }
+            Some((1.0 - dot).max(0.0).min(1.0))
+        };
+
+        let (fst, num_component, den_component) = match (dxy, pi1, pi2) {
+            (Some(d), Some(p1), Some(p2)) => {
+                if d > FST_EPSILON {
+                    let num = d - 0.5 * (p1 + p2);
+                    (Some(num / d), Some(num), Some(d))
+                } else {
+                    let pi_avg = 0.5 * (p1 + p2);
+                    if pi_avg.abs() <= FST_EPSILON {
+                        (Some(0.0), Some(0.0), Some(0.0))
+                    } else {
+                        (None, None, None)
+                    }
+                }
+            }
+            _ => (None, None, None),
+        };
+
+        sites.push(SiteFstHudson {
+            position: ZeroBasedPosition(variant.position).to_one_based(),
+            fst,
+            d_xy: dxy,
+            pi_pop1: pi1,
+            pi_pop2: pi2,
+            n1_called: n1,
+            n2_called: n2,
+            num_component,
+            den_component,
+        });
+
+        dense_reset_counts(&mut counts1, &mut used1);
+        dense_reset_counts(&mut counts2, &mut used2);
+    }
+
+    sites
+}
+
+fn dense_hudson_sites_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    variants: &[Variant],
+    pop1_mem: &DenseMembership,
+    pop2_mem: &DenseMembership,
+) -> Vec<SiteFstHudson> {
+    let offsets1 = pop1_mem.offsets();
+    let offsets2 = pop2_mem.offsets();
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut sites = Vec::with_capacity(variants.len());
+
+    match matrix.missing_slice() {
+        Some(bits) => {
+            for (variant_idx, variant) in variants.iter().enumerate() {
+                let base = variant_idx * stride;
+                let (n1, alt1) = dense_sum_alt_with_missing(data, base, offsets1, bits);
+                let (n2, alt2) = dense_sum_alt_with_missing(data, base, offsets2, bits);
+
+                let pi1 = dense_pi_from_counts(n1, alt1);
+                let pi2 = dense_pi_from_counts(n2, alt2);
+                let dxy = dense_dxy_from_biallelic_counts(n1, alt1, n2, alt2);
+
+                let (fst, num_component, den_component) =
+                    dense_fst_components_from_biallelic(dxy, pi1, pi2);
+
+                sites.push(SiteFstHudson {
+                    position: ZeroBasedPosition(variant.position).to_one_based(),
+                    fst,
+                    d_xy: dxy,
+                    pi_pop1: pi1,
+                    pi_pop2: pi2,
+                    n1_called: n1,
+                    n2_called: n2,
+                    num_component,
+                    den_component,
+                });
+            }
+        }
+        None => {
+            let n1_total = offsets1.len();
+            let n2_total = offsets2.len();
+            let n1_f = n1_total as f64;
+            let n2_f = n2_total as f64;
+            let scale1 = if n1_total >= 2 {
+                Some((n1_f / (n1_f - 1.0), 1.0 / (n1_f * n1_f)))
+            } else {
+                None
+            };
+            let scale2 = if n2_total >= 2 {
+                Some((n2_f / (n2_f - 1.0), 1.0 / (n2_f * n2_f)))
+            } else {
+                None
+            };
+
+            for (variant_idx, variant) in variants.iter().enumerate() {
+                let base = variant_idx * stride;
+                let alt1 = dense_sum_alt_no_missing(data, base, offsets1);
+                let alt2 = dense_sum_alt_no_missing(data, base, offsets2);
+
+                let pi1 = scale1.map(|(scale, inv_n_sq)| {
+                    if alt1 == 0 || alt1 == n1_total {
+                        0.0
+                    } else {
+                        let alt_f = alt1 as f64;
+                        let ref_f = (n1_total - alt1) as f64;
+                        scale * (1.0 - (ref_f * ref_f + alt_f * alt_f) * inv_n_sq)
+                    }
+                });
+                let pi2 = scale2.map(|(scale, inv_n_sq)| {
+                    if alt2 == 0 || alt2 == n2_total {
+                        0.0
+                    } else {
+                        let alt_f = alt2 as f64;
+                        let ref_f = (n2_total - alt2) as f64;
+                        scale * (1.0 - (ref_f * ref_f + alt_f * alt_f) * inv_n_sq)
+                    }
+                });
+
+                let dxy = dense_dxy_from_biallelic_counts(n1_total, alt1, n2_total, alt2);
+                let (fst, num_component, den_component) =
+                    dense_fst_components_from_biallelic(dxy, pi1, pi2);
+
+                sites.push(SiteFstHudson {
+                    position: ZeroBasedPosition(variant.position).to_one_based(),
+                    fst,
+                    d_xy: dxy,
+                    pi_pop1: pi1,
+                    pi_pop2: pi2,
+                    n1_called: n1_total,
+                    n2_called: n2_total,
+                    num_component,
+                    den_component,
+                });
+            }
+        }
+    }
+
+    sites
+}
+
 /// Aggregate per-site Hudson components into a window/regional FST using ratio of sums.
 ///
 /// Mathematical Foundation:
@@ -2096,14 +2949,7 @@ pub fn calculate_hudson_fst_per_site(
 /// Monomorphic Sites:
 /// Sites with D_xy = π = 0 contribute (0, 0) to the sums, which is mathematically correct.
 pub fn aggregate_hudson_from_sites(sites: &[SiteFstHudson]) -> Option<f64> {
-    let mut num_sum = 0.0_f64;
-    let mut den_sum = 0.0_f64;
-    for s in sites {
-        if let (Some(nc), Some(dc)) = (s.num_component, s.den_component) {
-            num_sum += nc;
-            den_sum += dc;
-        }
-    }
+    let (num_sum, den_sum) = hudson_component_sums(sites);
     if den_sum > FST_EPSILON {
         Some(num_sum / den_sum)
     } else if num_sum.abs() <= FST_EPSILON {
@@ -2238,6 +3084,11 @@ fn calculate_hudson_fst_for_pair_core<'a>(
     pop2_context: &PopulationContext<'a>,
     region: Option<QueryRegion>,
 ) -> Result<(HudsonFSTOutcome, Vec<SiteFstHudson>), VcfError> {
+    if pop1_context.sequence_length <= 0 {
+        return Err(VcfError::InvalidRegion(
+            "Sequence length must be positive for Hudson FST calculation.".to_string(),
+        ));
+    }
     if pop1_context.sequence_length != pop2_context.sequence_length {
         return Err(VcfError::Parse(
             "Sequence length mismatch between population contexts for Hudson FST calculation."
@@ -2250,52 +3101,113 @@ fn calculate_hudson_fst_for_pair_core<'a>(
         ));
     }
 
-    // Calculate per-site Hudson FST values
-    let site_values = if let Some(reg) = region {
-        calculate_hudson_fst_per_site(pop1_context, pop2_context, reg)
-    } else {
-        if pop1_context.variants.is_empty() {
-            Vec::new()
-        } else {
-            let pop1_mem =
-                HapMembership::build(pop1_context.sample_names.len(), &pop1_context.haplotypes);
-            let pop2_mem =
-                HapMembership::build(pop2_context.sample_names.len(), &pop2_context.haplotypes);
-            pop1_context
-                .variants
-                .iter()
-                .map(|variant| hudson_site_from_variant(variant, &pop1_mem, &pop2_mem))
-                .collect()
-        }
+    let summary_pair = match (
+        pop1_context.dense_summary.as_deref(),
+        pop2_context.dense_summary.as_deref(),
+    ) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
     };
 
-    // Compute regional FST using unbiased ratio-of-sums from per-site components
-    let regional_fst = aggregate_hudson_from_sites(&site_values);
+    let mut summary_totals: Option<HudsonSummaryTotals> = None;
+    let mut summary_refs: Option<(&DensePopulationSummary, &DensePopulationSummary)> = None;
+    let dense_shared = match (pop1_context.dense_genotypes, pop2_context.dense_genotypes) {
+        (Some(a), Some(b)) if std::ptr::eq(a, b) && a.ploidy() == 2 => Some(a),
+        _ => None,
+    };
+
+    let mut site_values = Vec::new();
+    let (num_sum, den_sum) = if let Some(reg) = region {
+        site_values = calculate_hudson_fst_per_site(pop1_context, pop2_context, reg);
+        hudson_component_sums(&site_values)
+    } else if let Some((summary1, summary2)) = summary_pair {
+        let totals = aggregate_hudson_components_from_summaries(summary1, summary2);
+        summary_totals = Some(totals);
+        summary_refs = Some((summary1, summary2));
+        (totals.numerator_sum, totals.denominator_sum)
+    } else if let Some(matrix) = dense_shared {
+        if pop1_context.variants.is_empty() {
+            (0.0, 0.0)
+        } else {
+            let pop1_mem = DenseMembership::build(matrix, &pop1_context.haplotypes);
+            let pop2_mem = DenseMembership::build(matrix, &pop2_context.haplotypes);
+            site_values = dense_hudson_sites(matrix, pop1_context.variants, &pop1_mem, &pop2_mem);
+            hudson_component_sums(&site_values)
+        }
+    } else if pop1_context.variants.is_empty() {
+        (0.0, 0.0)
+    } else {
+        let pop1_mem =
+            HapMembership::build(pop1_context.sample_names.len(), &pop1_context.haplotypes);
+        let pop2_mem =
+            HapMembership::build(pop2_context.sample_names.len(), &pop2_context.haplotypes);
+        site_values = pop1_context
+            .variants
+            .iter()
+            .map(|variant| hudson_site_from_variant(variant, &pop1_mem, &pop2_mem))
+            .collect();
+        hudson_component_sums(&site_values)
+    };
+
+    let regional_fst = if den_sum > FST_EPSILON {
+        Some(num_sum / den_sum)
+    } else if num_sum.abs() <= FST_EPSILON {
+        Some(0.0)
+    } else {
+        None
+    };
 
     // Calculate auxiliary π and Dxy values for output (but don't use for FST)
-    let pi1_raw = calculate_pi(
-        pop1_context.variants,
-        &pop1_context.haplotypes,
-        pop1_context.sequence_length,
-    );
+    let (pi1_raw, pi2_raw, dxy_result) = if let (Some((summary1, summary2)), Some(totals)) =
+        (summary_refs, summary_totals)
+    {
+        let pi1_raw = calculate_pi_from_summary_with_precomputed(
+            summary1,
+            pop1_context.sequence_length,
+            Some(totals.pi1_sum),
+        );
+        let pi2_raw = calculate_pi_from_summary_with_precomputed(
+            summary2,
+            pop2_context.sequence_length,
+            Some(totals.pi2_sum),
+        );
+
+        let dxy_value = if pop1_context.haplotypes.is_empty() || pop2_context.haplotypes.is_empty()
+        {
+            log(
+                LogLevel::Warning,
+                &format!(
+                    "Cannot calculate Dxy for pops {:?}/{:?}: one or both have no haplotypes ({} and {} respectively).",
+                    pop1_context.id,
+                    pop2_context.id,
+                    pop1_context.haplotypes.len(),
+                    pop2_context.haplotypes.len()
+                ),
+            );
+            None
+        } else {
+            Some(totals.dxy_sum_all / pop1_context.sequence_length as f64)
+        };
+
+        (pi1_raw, pi2_raw, DxyHudsonResult { d_xy: dxy_value })
+    } else {
+        let pi1_raw = calculate_pi_for_population(pop1_context);
+        let pi2_raw = calculate_pi_for_population(pop2_context);
+        let dxy_result = calculate_d_xy_hudson(pop1_context, pop2_context)?;
+        (pi1_raw, pi2_raw, dxy_result)
+    };
+
     let pi1_opt = if pi1_raw.is_finite() {
         Some(pi1_raw)
     } else {
         None
     };
 
-    let pi2_raw = calculate_pi(
-        pop2_context.variants,
-        &pop2_context.haplotypes,
-        pop2_context.sequence_length,
-    );
     let pi2_opt = if pi2_raw.is_finite() {
         Some(pi2_raw)
     } else {
         None
     };
-
-    let dxy_result = calculate_d_xy_hudson(pop1_context, pop2_context)?;
 
     // Create outcome with unbiased FST from per-site aggregation
     let mut outcome = HudsonFSTOutcome {
@@ -2514,15 +3426,142 @@ pub fn calculate_inversion_allele_frequency(
 
 // Count the number of segregating sites, where a site has more than one allele
 pub fn count_segregating_sites(variants: &[Variant]) -> usize {
-    // Returns the count as usize
     variants
-        .par_iter() // Use parallel iteration for efficiency over the variants slice
-        .filter(|v| {
-            // Collect all alleles across all genotypes into a HashSet to find unique alleles
-            let alleles: HashSet<_> = v.genotypes.iter().flatten().flatten().collect();
-            alleles.len() > 1 // True if the site is segregating (has multiple alleles)
-        })
-        .count() // Count the number of segregating sites
+        .par_iter()
+        .filter(|variant| variant_is_segregating(variant))
+        .count()
+}
+
+fn variant_is_segregating(variant: &Variant) -> bool {
+    let mut first = None;
+    for genotype_opt in &variant.genotypes {
+        if let Some(genotype) = genotype_opt {
+            for &allele in genotype {
+                match first {
+                    None => first = Some(allele),
+                    Some(value) if value != allele => return true,
+                    _ => {}
+                }
+            }
+        }
+    }
+    false
+}
+
+pub fn count_segregating_sites_for_population(context: &PopulationContext<'_>) -> usize {
+    if let Some(summary) = context.dense_summary.as_deref() {
+        return count_segregating_sites_from_summary(summary);
+    }
+    if let Some(matrix) = context.dense_genotypes {
+        if matrix.ploidy() == 2 {
+            let membership = DenseMembership::build(matrix, &context.haplotypes);
+            if membership.len() <= 1 {
+                return 0;
+            }
+            return count_segregating_sites_dense(matrix, &membership);
+        }
+    }
+    count_segregating_sites(context.variants)
+}
+
+fn count_segregating_sites_dense(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+) -> usize {
+    if matrix.max_allele() <= 1 {
+        return count_segregating_sites_dense_biallelic(matrix, membership);
+    }
+
+    let offsets = membership.offsets();
+    if offsets.is_empty() {
+        return 0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut segregating = 0usize;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let mut first: Option<u8> = None;
+            let mut polymorphic = false;
+            for &offset in offsets {
+                let idx = base + offset;
+                if dense_missing(bits, idx) {
+                    continue;
+                }
+                let allele = data[idx];
+                if let Some(value) = first {
+                    if allele != value {
+                        polymorphic = true;
+                        break;
+                    }
+                } else {
+                    first = Some(allele);
+                }
+            }
+            if polymorphic {
+                segregating += 1;
+            }
+        }
+    } else {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let mut first: Option<u8> = None;
+            let mut polymorphic = false;
+            for &offset in offsets {
+                let idx = base + offset;
+                let allele = data[idx];
+                if let Some(value) = first {
+                    if allele != value {
+                        polymorphic = true;
+                        break;
+                    }
+                } else {
+                    first = Some(allele);
+                }
+            }
+            if polymorphic {
+                segregating += 1;
+            }
+        }
+    }
+
+    segregating
+}
+
+fn count_segregating_sites_dense_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+) -> usize {
+    let offsets = membership.offsets();
+    if offsets.len() < 2 {
+        return 0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let total = offsets.len();
+    let mut segregating = 0usize;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            if called >= 2 && alt > 0 && alt < called {
+                segregating += 1;
+            }
+        }
+    } else {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            if alt > 0 && alt < total {
+                segregating += 1;
+            }
+        }
+    }
+
+    segregating
 }
 
 // Calculate pairwise differences and comparable sites between all sample pairs
@@ -2803,6 +3842,125 @@ pub fn calculate_pi(
     );
 
     pi
+}
+
+fn calculate_pi_dense_biallelic(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    seq_length: i64,
+) -> f64 {
+    let offsets = membership.offsets();
+    if offsets.len() <= 1 {
+        return 0.0;
+    }
+    let stride = matrix.stride();
+    let data = matrix.data();
+    let mut sum_pi = 0.0_f64;
+
+    if let Some(bits) = matrix.missing_slice() {
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let (total_called, alt_count) = dense_sum_alt_with_missing(data, base, offsets, bits);
+            if let Some(pi) = dense_pi_from_counts(total_called, alt_count) {
+                sum_pi += pi;
+            }
+        }
+    } else {
+        let total = offsets.len();
+        if total < 2 {
+            return 0.0;
+        }
+        let n = total as f64;
+        let scale = n / (n - 1.0);
+        let inv_n_sq = 1.0 / (n * n);
+        for variant_idx in 0..matrix.variant_count() {
+            let base = variant_idx * stride;
+            let alt = dense_sum_alt_no_missing(data, base, offsets);
+            if alt == 0 || alt == total {
+                continue;
+            }
+            let alt_f = alt as f64;
+            let ref_f = (total - alt) as f64;
+            let sum_sq = ref_f * ref_f + alt_f * alt_f;
+            sum_pi += scale * (1.0 - sum_sq * inv_n_sq);
+        }
+    }
+
+    sum_pi / seq_length as f64
+}
+
+fn calculate_pi_dense(
+    matrix: &DenseGenotypeMatrix,
+    membership: &DenseMembership,
+    seq_length: i64,
+) -> f64 {
+    if membership.len() <= 1 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: insufficient haplotypes ({})",
+                membership.len()
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length < 0 {
+        log(
+            LogLevel::Warning,
+            &format!(
+                "Cannot calculate pi: invalid sequence length ({})",
+                seq_length
+            ),
+        );
+        return 0.0;
+    }
+
+    if seq_length == 0 {
+        log(
+            LogLevel::Warning,
+            "Cannot calculate pi: zero sequence length causes division by zero",
+        );
+        return f64::INFINITY;
+    }
+
+    if matrix.max_allele() <= 1 {
+        return calculate_pi_dense_biallelic(matrix, membership, seq_length);
+    }
+
+    let mut counts = vec![0u32; 256];
+    let mut used = Vec::with_capacity(8);
+    let mut sum_pi = 0.0_f64;
+
+    for variant_idx in 0..matrix.variant_count() {
+        let (total_called, sum_counts_sq) =
+            dense_collect_counts(matrix, membership, variant_idx, &mut counts, &mut used);
+        if total_called >= 2 {
+            let n = total_called as f64;
+            let sum_p2 = sum_counts_sq / (n * n);
+            sum_pi += n / (n - 1.0) * (1.0 - sum_p2);
+        }
+        dense_reset_counts(&mut counts, &mut used);
+    }
+
+    sum_pi / seq_length as f64
+}
+
+pub fn calculate_pi_for_population(context: &PopulationContext<'_>) -> f64 {
+    if let Some(summary) = context.dense_summary.as_deref() {
+        return calculate_pi_from_summary(summary, context.sequence_length);
+    }
+    if let Some(matrix) = context.dense_genotypes {
+        if matrix.ploidy() == 2 {
+            let membership = DenseMembership::build(matrix, &context.haplotypes);
+            return calculate_pi_dense(matrix, &membership, context.sequence_length);
+        }
+    }
+    calculate_pi(
+        context.variants,
+        &context.haplotypes,
+        context.sequence_length,
+    )
 }
 
 /// Calculate per-site diversity metrics (π and Watterson's θ) across a genomic region.

--- a/src/tests/hudson_fst_tests.rs
+++ b/src/tests/hudson_fst_tests.rs
@@ -15,46 +15,74 @@ mod hudson_fst_tests {
     fn test_hudson_fst_per_site_calculation() {
         // Test case 1: Perfect population structure (FST should be 1.0)
         // Pop1: all 0|0, Pop2: all 1|1
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            Some(vec![0, 0]), // sample 1 - pop1  
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                Some(vec![0, 0]), // sample 1 - pop1
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right), 
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
-            id: PopulationId::HaplotypeGroup(1), 
+            id: PopulationId::HaplotypeGroup(1),
             haplotypes: pop2_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         // Test the Hudson FST calculation
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("Perfect structure FST: {:?}", outcome.fst);
-        
+
         // With perfect population structure, FST should be close to 1.0
         if let Some(fst) = outcome.fst {
-            assert!(fst > 0.8, "FST {} is too low for perfect population structure", fst);
+            assert!(
+                fst > 0.8,
+                "FST {} is too low for perfect population structure",
+                fst
+            );
             assert!(fst <= 1.0, "FST {} exceeds maximum value of 1.0", fst);
         } else {
             panic!("FST calculation returned None for perfect population structure");
@@ -65,26 +93,44 @@ mod hudson_fst_tests {
     fn test_hudson_fst_no_structure() {
         // Test case 2: No population structure (FST should be ~0)
         // Both populations have same allele frequencies
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 1]), // sample 0 - pop1 (heterozygous)
-            Some(vec![1, 0]), // sample 1 - pop1 (heterozygous)
-            Some(vec![0, 1]), // sample 2 - pop2 (heterozygous) 
-            Some(vec![1, 0]), // sample 3 - pop2 (heterozygous)
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 1]), // sample 0 - pop1 (heterozygous)
+                Some(vec![1, 0]), // sample 1 - pop1 (heterozygous)
+                Some(vec![0, 1]), // sample 2 - pop2 (heterozygous)
+                Some(vec![1, 0]), // sample 3 - pop2 (heterozygous)
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -93,49 +139,80 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("No structure FST: {:?}", outcome.fst);
-        
+
         // With no population structure, FST can be negative (which is expected)
         // The negative value indicates that within-population diversity is higher than between-population diversity
         if let Some(fst) = outcome.fst {
-            assert!(fst >= -1.0 && fst <= 1.0, "FST {} is outside valid range [-1, 1]", fst);
+            assert!(
+                fst >= -1.0 && fst <= 1.0,
+                "FST {} is outside valid range [-1, 1]",
+                fst
+            );
             // For this specific case with identical allele frequencies but different arrangements,
             // negative FST is mathematically correct
-            println!("FST = {} is within expected range for this data pattern", fst);
+            println!(
+                "FST = {} is within expected range for this data pattern",
+                fst
+            );
         } else {
             panic!("FST calculation returned None for valid data");
         }
     }
 
-    #[test] 
+    #[test]
     fn test_hudson_fst_per_site_components() {
         // Test that per-site components are correctly calculated
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            Some(vec![0, 0]), // sample 1 - pop1
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                Some(vec![0, 0]), // sample 1 - pop1
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -144,46 +221,73 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
-        let region = QueryRegion { start: 99, end: 101 }; // 0-based, so 99-101 covers position 100
+        let region = QueryRegion {
+            start: 99,
+            end: 101,
+        }; // 0-based, so 99-101 covers position 100
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_ok(), "Hudson FST with sites calculation failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST with sites calculation failed: {:?}",
+            result.err()
+        );
 
         let (outcome, sites) = result.unwrap();
-        
+
         println!("Number of sites returned: {}", sites.len());
         for (i, site) in sites.iter().enumerate() {
-            println!("Site {}: pos={}, fst={:?}, dxy={:?}", i, site.position, site.fst, site.d_xy);
+            println!(
+                "Site {}: pos={}, fst={:?}, dxy={:?}",
+                i, site.position, site.fst, site.d_xy
+            );
         }
-        
+
         // Find the site at position 101 (where the actual data is)
         let site_101 = sites.iter().find(|s| s.position == 101);
         assert!(site_101.is_some(), "Site at position 101 not found");
-        
+
         let site = site_101.unwrap();
         println!("Site 101 FST: {:?}", site.fst);
         println!("Site 101 D_xy: {:?}", site.d_xy);
         println!("Site 101 pi_pop1: {:?}", site.pi_pop1);
         println!("Site 101 pi_pop2: {:?}", site.pi_pop2);
-        
+
         // With perfect structure: D_xy should be 1.0, pi should be 0.0
         assert!(site.d_xy.is_some(), "D_xy should be calculated");
         assert!(site.pi_pop1.is_some(), "pi_pop1 should be calculated");
         assert!(site.pi_pop2.is_some(), "pi_pop2 should be calculated");
-        
+
         if let (Some(dxy), Some(pi1), Some(pi2)) = (site.d_xy, site.pi_pop1, site.pi_pop2) {
-            assert!((dxy - 1.0).abs() < 0.01, "D_xy should be ~1.0 for perfect structure, got {}", dxy);
-            assert!(pi1.abs() < 0.01, "pi_pop1 should be ~0.0 for monomorphic population, got {}", pi1);
-            assert!(pi2.abs() < 0.01, "pi_pop2 should be ~0.0 for monomorphic population, got {}", pi2);
+            assert!(
+                (dxy - 1.0).abs() < 0.01,
+                "D_xy should be ~1.0 for perfect structure, got {}",
+                dxy
+            );
+            assert!(
+                pi1.abs() < 0.01,
+                "pi_pop1 should be ~0.0 for monomorphic population, got {}",
+                pi1
+            );
+            assert!(
+                pi2.abs() < 0.01,
+                "pi_pop2 should be ~0.0 for monomorphic population, got {}",
+                pi2
+            );
         }
-        
+
         // Regional FST should match per-site aggregation
         if let Some(regional_fst) = outcome.fst {
             if let Some(site_fst) = site.fst {
-                assert!((regional_fst - site_fst).abs() < 0.01, 
-                    "Regional FST {} should match site FST {} for single-site region", 
-                    regional_fst, site_fst);
+                assert!(
+                    (regional_fst - site_fst).abs() < 0.01,
+                    "Regional FST {} should match site FST {} for single-site region",
+                    regional_fst,
+                    site_fst
+                );
             }
         }
     }
@@ -206,7 +310,12 @@ mod hudson_fst_tests {
 
         // No variants - monomorphic region
         let variants = vec![];
-        let sample_names = vec!["sample1".to_string(), "sample2".to_string(), "sample3".to_string(), "sample4".to_string()];
+        let sample_names = vec![
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
+            "sample4".to_string(),
+        ];
 
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
@@ -214,6 +323,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -222,60 +333,87 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation should succeed for monomorphic window");
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation should succeed for monomorphic window"
+        );
 
         let outcome = result.unwrap();
         println!("Monomorphic window FST: {:?}", outcome.fst);
 
         // Monomorphic windows should return FST = 0.0, not None
-        assert!(outcome.fst.is_some(), "Monomorphic window should have FST = 0.0, not None");
-        assert_eq!(outcome.fst.unwrap(), 0.0, "Monomorphic window FST should be exactly 0.0");
+        assert!(
+            outcome.fst.is_some(),
+            "Monomorphic window should have FST = 0.0, not None"
+        );
+        assert_eq!(
+            outcome.fst.unwrap(),
+            0.0,
+            "Monomorphic window FST should be exactly 0.0"
+        );
     }
 
     #[test]
     fn test_hudson_fst_ratio_of_sums_no_missingness() {
         // Test 1: Ratio-of-sums with no missingness (two sites, mixed structure)
         // Expected regional FST = 5/9 ≈ 0.5555555556
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): perfect structure
         // sample0: [0,0], sample1: [0,0], sample2: [1,1], sample3: [1,1]
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 0]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 0]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         // Site B (pos=200): identical pop frequencies (each pop has 2×0 and 2×1)
         // sample0: [0,1], sample1: [0,1], sample2: [0,1], sample3: [0,1]
-        let variant_b = create_test_variant(200, vec![
-            Some(vec![0, 1]), // sample0
-            Some(vec![0, 1]), // sample1
-            Some(vec![0, 1]), // sample2
-            Some(vec![0, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                Some(vec![0, 1]), // sample0
+                Some(vec![0, 1]), // sample1
+                Some(vec![0, 1]), // sample2
+                Some(vec![0, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         // pop1 = samples {0,1}, pop2 = samples {2,3}
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -284,6 +422,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -292,85 +432,140 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data (non-None FST)
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Site A (position 101 in 1-based): perfect structure
-        let site_a = variant_sites.iter().find(|s| s.position == 101).expect("Site A not found");
-        assert!((site_a.fst.unwrap() - 1.0).abs() < 1e-12, "Site A FST should be exactly 1.0");
-        assert!((site_a.num_component.unwrap() - 1.0).abs() < 1e-12, "Site A numerator should be 1.0");
-        assert!((site_a.den_component.unwrap() - 1.0).abs() < 1e-12, "Site A denominator should be 1.0");
+        let site_a = variant_sites
+            .iter()
+            .find(|s| s.position == 101)
+            .expect("Site A not found");
+        assert!(
+            (site_a.fst.unwrap() - 1.0).abs() < 1e-12,
+            "Site A FST should be exactly 1.0"
+        );
+        assert!(
+            (site_a.num_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A numerator should be 1.0"
+        );
+        assert!(
+            (site_a.den_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A denominator should be 1.0"
+        );
 
         // Site B (position 201 in 1-based): FST = -1/3
-        let site_b = variant_sites.iter().find(|s| s.position == 201).expect("Site B not found");
-        assert!((site_b.fst.unwrap() - (-1.0/3.0)).abs() < 1e-12, "Site B FST should be exactly -1/3");
-        assert!((site_b.num_component.unwrap() - (-1.0/6.0)).abs() < 1e-12, "Site B numerator should be -1/6");
-        assert!((site_b.den_component.unwrap() - 0.5).abs() < 1e-12, "Site B denominator should be 0.5");
+        let site_b = variant_sites
+            .iter()
+            .find(|s| s.position == 201)
+            .expect("Site B not found");
+        assert!(
+            (site_b.fst.unwrap() - (-1.0 / 3.0)).abs() < 1e-12,
+            "Site B FST should be exactly -1/3"
+        );
+        assert!(
+            (site_b.num_component.unwrap() - (-1.0 / 6.0)).abs() < 1e-12,
+            "Site B numerator should be -1/6"
+        );
+        assert!(
+            (site_b.den_component.unwrap() - 0.5).abs() < 1e-12,
+            "Site B denominator should be 0.5"
+        );
 
         // Regional FST from ratio-of-sums: (5/6) / (3/2) = 5/9
         let expected_regional_fst = 5.0 / 9.0;
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
-        assert!((aggregated_fst - expected_regional_fst).abs() < 1e-12, 
-            "Aggregated FST should be exactly 5/9, got {}", aggregated_fst);
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
+        assert!(
+            (aggregated_fst - expected_regional_fst).abs() < 1e-12,
+            "Aggregated FST should be exactly 5/9, got {}",
+            aggregated_fst
+        );
 
         // Window FST should match (if using unbiased implementation)
         assert!(outcome.fst.is_some(), "Window FST should be Some");
-        assert!((outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
-            "Window FST should match ratio-of-sums: expected {}, got {}", 
-            expected_regional_fst, outcome.fst.unwrap());
+        assert!(
+            (outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
+            "Window FST should match ratio-of-sums: expected {}, got {}",
+            expected_regional_fst,
+            outcome.fst.unwrap()
+        );
 
-        println!("Test 1 PASSED: Regional FST = {} (expected 5/9 = {})", 
-            outcome.fst.unwrap(), expected_regional_fst);
+        println!(
+            "Test 1 PASSED: Regional FST = {} (expected 5/9 = {})",
+            outcome.fst.unwrap(),
+            expected_regional_fst
+        );
     }
 
     #[test]
     fn test_hudson_fst_ratio_of_sums_uneven_missingness() {
         // Test 2: Ratio-of-sums under uneven missingness
         // Expected regional FST = 1/3 ≈ 0.3333333333
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): perfect structure (same as Test 1)
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 0]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 0]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         // Site B (pos=200): missing data for samples 0 and 2
         // sample0: None, sample1: [0,1], sample2: None, sample3: [0,1]
         // This gives each pop n=2 with {0:1, 1:1}
-        let variant_b = create_test_variant(200, vec![
-            None,           // sample0 - missing
-            Some(vec![0, 1]), // sample1
-            None,           // sample2 - missing  
-            Some(vec![0, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                None,             // sample0 - missing
+                Some(vec![0, 1]), // sample1
+                None,             // sample2 - missing
+                Some(vec![0, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -379,6 +574,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -387,67 +584,116 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data (non-None FST)
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Site A unchanged (FST=1, num=1, den=1)
-        let site_a = variant_sites.iter().find(|s| s.position == 101).expect("Site A not found");
-        assert!((site_a.fst.unwrap() - 1.0).abs() < 1e-12, "Site A FST should be exactly 1.0");
-        assert!((site_a.num_component.unwrap() - 1.0).abs() < 1e-12, "Site A numerator should be 1.0");
-        assert!((site_a.den_component.unwrap() - 1.0).abs() < 1e-12, "Site A denominator should be 1.0");
+        let site_a = variant_sites
+            .iter()
+            .find(|s| s.position == 101)
+            .expect("Site A not found");
+        assert!(
+            (site_a.fst.unwrap() - 1.0).abs() < 1e-12,
+            "Site A FST should be exactly 1.0"
+        );
+        assert!(
+            (site_a.num_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A numerator should be 1.0"
+        );
+        assert!(
+            (site_a.den_component.unwrap() - 1.0).abs() < 1e-12,
+            "Site A denominator should be 1.0"
+        );
 
         // Site B with missingness: FST = -1, num = -0.5, den = 0.5
-        let site_b = variant_sites.iter().find(|s| s.position == 201).expect("Site B not found");
-        assert!((site_b.fst.unwrap() - (-1.0)).abs() < 1e-12, "Site B FST should be exactly -1.0");
-        assert!((site_b.num_component.unwrap() - (-0.5)).abs() < 1e-12, "Site B numerator should be -0.5");
-        assert!((site_b.den_component.unwrap() - 0.5).abs() < 1e-12, "Site B denominator should be 0.5");
+        let site_b = variant_sites
+            .iter()
+            .find(|s| s.position == 201)
+            .expect("Site B not found");
+        assert!(
+            (site_b.fst.unwrap() - (-1.0)).abs() < 1e-12,
+            "Site B FST should be exactly -1.0"
+        );
+        assert!(
+            (site_b.num_component.unwrap() - (-0.5)).abs() < 1e-12,
+            "Site B numerator should be -0.5"
+        );
+        assert!(
+            (site_b.den_component.unwrap() - 0.5).abs() < 1e-12,
+            "Site B denominator should be 0.5"
+        );
 
         // Regional FST: (1 + (-0.5)) / (1 + 0.5) = 0.5 / 1.5 = 1/3
         let expected_regional_fst = 1.0 / 3.0;
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
-        assert!((aggregated_fst - expected_regional_fst).abs() < 1e-12, 
-            "Aggregated FST should be exactly 1/3, got {}", aggregated_fst);
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some");
+        assert!(
+            (aggregated_fst - expected_regional_fst).abs() < 1e-12,
+            "Aggregated FST should be exactly 1/3, got {}",
+            aggregated_fst
+        );
 
         // Window FST should match
         assert!(outcome.fst.is_some(), "Window FST should be Some");
-        assert!((outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
-            "Window FST should match ratio-of-sums: expected {}, got {}", 
-            expected_regional_fst, outcome.fst.unwrap());
+        assert!(
+            (outcome.fst.unwrap() - expected_regional_fst).abs() < 1e-12,
+            "Window FST should match ratio-of-sums: expected {}, got {}",
+            expected_regional_fst,
+            outcome.fst.unwrap()
+        );
 
-        println!("Test 2 PASSED: Regional FST = {} (expected 1/3 = {})", 
-            outcome.fst.unwrap(), expected_regional_fst);
+        println!(
+            "Test 2 PASSED: Regional FST = {} (expected 1/3 = {})",
+            outcome.fst.unwrap(),
+            expected_regional_fst
+        );
     }
 
     #[test]
     fn test_hudson_fst_monomorphic_window_surgical() {
         // Test 3: Monomorphic window ⇒ overall Hudson FST = 0
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // No variants at all
         let variants = vec![];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 102 };
+        let region = QueryRegion {
+            start: 100,
+            end: 102,
+        };
         let sequence_length = (region.end - region.start + 1) as i64; // 3
 
         let pop1_context = PopulationContext {
@@ -456,6 +702,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -464,72 +712,111 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Should have 3 sites (positions 100, 101, 102), all with no data
         assert_eq!(sites.len(), 3, "Should have exactly 3 sites in region");
 
         // Each site should have None for all components
         for site in &sites {
-            assert!(site.fst.is_none(), "Site {} FST should be None", site.position);
-            assert!(site.num_component.is_none(), "Site {} num_component should be None", site.position);
-            assert!(site.den_component.is_none(), "Site {} den_component should be None", site.position);
+            assert!(
+                site.fst.is_none(),
+                "Site {} FST should be None",
+                site.position
+            );
+            assert!(
+                site.num_component.is_none(),
+                "Site {} num_component should be None",
+                site.position
+            );
+            assert!(
+                site.den_component.is_none(),
+                "Site {} den_component should be None",
+                site.position
+            );
         }
 
         // Aggregated FST should be 0.0 (Σnum = 0, Σden = 0)
-        let aggregated_fst = aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some(0.0)");
-        assert!((aggregated_fst - 0.0).abs() < 1e-12, "Aggregated FST should be exactly 0.0");
+        let aggregated_fst =
+            aggregate_hudson_from_sites(&sites).expect("Aggregated FST should be Some(0.0)");
+        assert!(
+            (aggregated_fst - 0.0).abs() < 1e-12,
+            "Aggregated FST should be exactly 0.0"
+        );
 
         // Window FST should also be 0.0
         assert!(outcome.fst.is_some(), "Window FST should be Some(0.0)");
-        assert!((outcome.fst.unwrap() - 0.0).abs() < 1e-12, "Window FST should be exactly 0.0");
+        assert!(
+            (outcome.fst.unwrap() - 0.0).abs() < 1e-12,
+            "Window FST should be exactly 0.0"
+        );
 
-        println!("Test 3 PASSED: Monomorphic window FST = {} (expected 0.0)", outcome.fst.unwrap());
+        println!(
+            "Test 3 PASSED: Monomorphic window FST = {} (expected 0.0)",
+            outcome.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_pi_dxy_consistency_with_uneven_coverage() {
         // Test that π/Dxy calculations are consistent with per-site math
         // when pairs have different numbers of comparable sites
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Site A (pos=100): all samples have data
-        let variant_a = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0
-            Some(vec![0, 1]), // sample1  
-            Some(vec![1, 1]), // sample2
-            Some(vec![1, 0]), // sample3
-        ]);
+        let variant_a = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0
+                Some(vec![0, 1]), // sample1
+                Some(vec![1, 1]), // sample2
+                Some(vec![1, 0]), // sample3
+            ],
+        );
 
         // Site B (pos=200): only samples 1 and 3 have data (uneven coverage)
-        let variant_b = create_test_variant(200, vec![
-            None,             // sample0 - missing
-            Some(vec![0, 0]), // sample1
-            None,             // sample2 - missing
-            Some(vec![1, 1]), // sample3
-        ]);
+        let variant_b = create_test_variant(
+            200,
+            vec![
+                None,             // sample0 - missing
+                Some(vec![0, 0]), // sample1
+                None,             // sample2 - missing
+                Some(vec![1, 1]), // sample3
+            ],
+        );
 
         let variants = vec![variant_a, variant_b];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
         let sequence_length = 2; // Only 2 variant sites
 
         let pop1_context = PopulationContext {
@@ -538,6 +825,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -546,29 +835,29 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (outcome, sites) = result.unwrap();
-        
+
         // Filter to only sites with actual data
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
-        
+
         // Should have 2 variant sites but with different coverage patterns
-        assert_eq!(variant_sites.len(), 2, "Should have exactly 2 variant sites");
+        assert_eq!(
+            variant_sites.len(),
+            2,
+            "Should have exactly 2 variant sites"
+        );
 
         // Verify that π and Dxy values are consistent with per-site aggregation
-        let manual_pi1_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.pi_pop1)
-            .sum();
-        let manual_pi2_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.pi_pop2)
-            .sum();
-        let manual_dxy_sum: f64 = variant_sites.iter()
-            .filter_map(|s| s.d_xy)
-            .sum();
+        let manual_pi1_sum: f64 = variant_sites.iter().filter_map(|s| s.pi_pop1).sum();
+        let manual_pi2_sum: f64 = variant_sites.iter().filter_map(|s| s.pi_pop2).sum();
+        let manual_dxy_sum: f64 = variant_sites.iter().filter_map(|s| s.d_xy).sum();
 
         let expected_pi1 = manual_pi1_sum / sequence_length as f64;
         let expected_pi2 = manual_pi2_sum / sequence_length as f64;
@@ -576,21 +865,30 @@ mod hudson_fst_tests {
 
         // The reported π/Dxy should match per-site aggregation
         if let Some(reported_pi1) = outcome.pi_pop1 {
-            assert!((reported_pi1 - expected_pi1).abs() < 1e-12, 
-                "Reported π1 ({}) should match per-site aggregation ({})", 
-                reported_pi1, expected_pi1);
+            assert!(
+                (reported_pi1 - expected_pi1).abs() < 1e-12,
+                "Reported π1 ({}) should match per-site aggregation ({})",
+                reported_pi1,
+                expected_pi1
+            );
         }
 
         if let Some(reported_pi2) = outcome.pi_pop2 {
-            assert!((reported_pi2 - expected_pi2).abs() < 1e-12, 
-                "Reported π2 ({}) should match per-site aggregation ({})", 
-                reported_pi2, expected_pi2);
+            assert!(
+                (reported_pi2 - expected_pi2).abs() < 1e-12,
+                "Reported π2 ({}) should match per-site aggregation ({})",
+                reported_pi2,
+                expected_pi2
+            );
         }
 
         if let Some(reported_dxy) = outcome.d_xy {
-            assert!((reported_dxy - expected_dxy).abs() < 1e-12, 
-                "Reported Dxy ({}) should match per-site aggregation ({})", 
-                reported_dxy, expected_dxy);
+            assert!(
+                (reported_dxy - expected_dxy).abs() < 1e-12,
+                "Reported Dxy ({}) should match per-site aggregation ({})",
+                reported_dxy,
+                expected_dxy
+            );
         }
 
         println!("π/Dxy consistency test PASSED: per-site aggregation matches reported values");
@@ -600,34 +898,46 @@ mod hudson_fst_tests {
     fn test_hudson_fst_multi_allelic_site() {
         // Test multi-allelic site: 3 alleles with different frequencies between populations
         // pop1: A/C/G at 0.5/0.25/0.25 vs pop2: A/C/G at 0.2/0.3/0.5
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Multi-allelic site with alleles 0=A, 1=C, 2=G
         // pop1: 2×A, 1×C, 1×G → frequencies: A=0.5, C=0.25, G=0.25
         // pop2: 1×A, 1×C, 2×G → frequencies: A=0.25, C=0.25, G=0.5
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample0: A/A (pop1)
-            Some(vec![1, 2]), // sample1: C/G (pop1)
-            Some(vec![0, 1]), // sample2: A/C (pop2)
-            Some(vec![2, 2]), // sample3: G/G (pop2)
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample0: A/A (pop1)
+                Some(vec![1, 2]), // sample1: C/G (pop1)
+                Some(vec![0, 1]), // sample2: A/C (pop2)
+                Some(vec![2, 2]), // sample3: G/G (pop2)
+            ],
+        );
 
         let variants = vec![variant];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 100 };
+        let region = QueryRegion {
+            start: 100,
+            end: 100,
+        };
         let sequence_length = 1;
 
         let pop1_context = PopulationContext {
@@ -636,6 +946,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -644,80 +956,118 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_ok(), "Hudson FST calculation should succeed for multi-allelic site");
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation should succeed for multi-allelic site"
+        );
 
         let (_outcome, sites) = result.unwrap();
-        
+
         let variant_sites: Vec<_> = sites.iter().filter(|s| s.fst.is_some()).collect();
         assert_eq!(variant_sites.len(), 1, "Should have exactly 1 variant site");
 
         let site = variant_sites[0];
-        
+
         // Manual calculation for verification:
         // pop1 frequencies: p1A=0.5, p1C=0.25, p1G=0.25
         // pop2 frequencies: p2A=0.25, p2C=0.25, p2G=0.5
         // Dxy = 1 - (p1A*p2A + p1C*p2C + p1G*p2G) = 1 - (0.5*0.25 + 0.25*0.25 + 0.25*0.5) = 1 - 0.3125 = 0.6875
         let expected_dxy = 0.6875;
-        
+
         // π1 = (4/3) * (1 - (0.5² + 0.25² + 0.25²)) = (4/3) * (1 - 0.375) = (4/3) * 0.625 = 0.8333...
-        let expected_pi1 = (4.0/3.0) * (1.0 - (0.5*0.5 + 0.25*0.25 + 0.25*0.25));
-        
+        let expected_pi1 = (4.0 / 3.0) * (1.0 - (0.5 * 0.5 + 0.25 * 0.25 + 0.25 * 0.25));
+
         // π2 = (4/3) * (1 - (0.25² + 0.25² + 0.5²)) = (4/3) * (1 - 0.375) = (4/3) * 0.625 = 0.8333...
-        let expected_pi2 = (4.0/3.0) * (1.0 - (0.25*0.25 + 0.25*0.25 + 0.5*0.5));
-        
+        let expected_pi2 = (4.0 / 3.0) * (1.0 - (0.25 * 0.25 + 0.25 * 0.25 + 0.5 * 0.5));
+
         // numerator = Dxy - 0.5*(π1 + π2)
         let expected_numerator = expected_dxy - 0.5 * (expected_pi1 + expected_pi2);
         let expected_fst = expected_numerator / expected_dxy;
 
-        assert!((site.d_xy.unwrap() - expected_dxy).abs() < 1e-12, 
-            "Multi-allelic Dxy should be {}, got {}", expected_dxy, site.d_xy.unwrap());
-        
-        assert!((site.pi_pop1.unwrap() - expected_pi1).abs() < 1e-12,
-            "Multi-allelic π1 should be {}, got {}", expected_pi1, site.pi_pop1.unwrap());
-            
-        assert!((site.pi_pop2.unwrap() - expected_pi2).abs() < 1e-12,
-            "Multi-allelic π2 should be {}, got {}", expected_pi2, site.pi_pop2.unwrap());
+        assert!(
+            (site.d_xy.unwrap() - expected_dxy).abs() < 1e-12,
+            "Multi-allelic Dxy should be {}, got {}",
+            expected_dxy,
+            site.d_xy.unwrap()
+        );
 
-        assert!((site.fst.unwrap() - expected_fst).abs() < 1e-12,
-            "Multi-allelic FST should be {}, got {}", expected_fst, site.fst.unwrap());
+        assert!(
+            (site.pi_pop1.unwrap() - expected_pi1).abs() < 1e-12,
+            "Multi-allelic π1 should be {}, got {}",
+            expected_pi1,
+            site.pi_pop1.unwrap()
+        );
 
-        println!("Multi-allelic test PASSED: Dxy={:.6}, π1={:.6}, π2={:.6}, FST={:.6}", 
-            site.d_xy.unwrap(), site.pi_pop1.unwrap(), site.pi_pop2.unwrap(), site.fst.unwrap());
+        assert!(
+            (site.pi_pop2.unwrap() - expected_pi2).abs() < 1e-12,
+            "Multi-allelic π2 should be {}, got {}",
+            expected_pi2,
+            site.pi_pop2.unwrap()
+        );
+
+        assert!(
+            (site.fst.unwrap() - expected_fst).abs() < 1e-12,
+            "Multi-allelic FST should be {}, got {}",
+            expected_fst,
+            site.fst.unwrap()
+        );
+
+        println!(
+            "Multi-allelic test PASSED: Dxy={:.6}, π1={:.6}, π2={:.6}, FST={:.6}",
+            site.d_xy.unwrap(),
+            site.pi_pop1.unwrap(),
+            site.pi_pop2.unwrap(),
+            site.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_hudson_fst_identical_frequencies() {
         // Test case: identical allele frequencies between populations
         // This should give FST close to 0 (but may be slightly negative due to sampling)
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Both populations have identical frequencies: 50% A, 50% T
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 1]), // sample0: A/T (pop1)
-            Some(vec![1, 0]), // sample1: T/A (pop1) → pop1: 50% A, 50% T
-            Some(vec![0, 1]), // sample2: A/T (pop2)  
-            Some(vec![1, 0]), // sample3: T/A (pop2) → pop2: 50% A, 50% T
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 1]), // sample0: A/T (pop1)
+                Some(vec![1, 0]), // sample1: T/A (pop1) → pop1: 50% A, 50% T
+                Some(vec![0, 1]), // sample2: A/T (pop2)
+                Some(vec![1, 0]), // sample3: T/A (pop2) → pop2: 50% A, 50% T
+            ],
+        );
 
         let variants = vec![variant];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 100 };
+        let region = QueryRegion {
+            start: 100,
+            end: 100,
+        };
         let sequence_length = 1;
 
         let pop1_context = PopulationContext {
@@ -726,6 +1076,8 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -734,57 +1086,90 @@ mod hudson_fst_tests {
             variants: &variants,
             sample_names: &sample_names,
             sequence_length,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
         assert!(result.is_ok(), "Hudson FST calculation should succeed");
 
         let (_outcome, sites) = result.unwrap();
-        
+
         assert_eq!(sites.len(), 1, "Should have exactly 1 site");
         let site = &sites[0];
-        
+
         assert!(site.d_xy.is_some(), "Dxy should be calculable");
-        assert!(site.pi_pop1.is_some(), "π1 should be calculable");  
+        assert!(site.pi_pop1.is_some(), "π1 should be calculable");
         assert!(site.pi_pop2.is_some(), "π2 should be calculable");
-        assert!(site.fst.is_some(), "FST should be calculable for identical frequencies");
-        
+        assert!(
+            site.fst.is_some(),
+            "FST should be calculable for identical frequencies"
+        );
+
         // With identical frequencies, FST can be negative due to finite sample corrections
         // The key is that it should be calculable (not None) and within reasonable bounds
-        assert!(site.fst.unwrap() >= -1.0 && site.fst.unwrap() <= 1.0, 
-            "FST should be within [-1,1] bounds, got {}", site.fst.unwrap());
+        assert!(
+            site.fst.unwrap() >= -1.0 && site.fst.unwrap() <= 1.0,
+            "FST should be within [-1,1] bounds, got {}",
+            site.fst.unwrap()
+        );
 
-        println!("Identical frequencies test PASSED: FST = {} (within bounds)", site.fst.unwrap());
+        println!(
+            "Identical frequencies test PASSED: FST = {} (within bounds)",
+            site.fst.unwrap()
+        );
     }
 
     #[test]
     fn test_hudson_fst_variant_compatibility_guard() {
         // Test that calculate_hudson_fst_per_site guards against variant incompatibility
-        
+
         let sample_names = vec![
-            "sample0".to_string(), "sample1".to_string(), 
-            "sample2".to_string(), "sample3".to_string()
+            "sample0".to_string(),
+            "sample1".to_string(),
+            "sample2".to_string(),
+            "sample3".to_string(),
         ];
 
         // Different variants for each population (incompatible)
-        let variants1 = vec![create_test_variant(100, vec![
-            Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), Some(vec![1, 0])
-        ])];
-        
-        let variants2 = vec![create_test_variant(200, vec![ // Different position!
-            Some(vec![0, 0]), Some(vec![0, 1]), Some(vec![1, 1]), Some(vec![1, 0])
-        ])];
+        let variants1 = vec![create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]),
+                Some(vec![0, 1]),
+                Some(vec![1, 1]),
+                Some(vec![1, 0]),
+            ],
+        )];
+
+        let variants2 = vec![create_test_variant(
+            200,
+            vec![
+                // Different position!
+                Some(vec![0, 0]),
+                Some(vec![0, 1]),
+                Some(vec![1, 1]),
+                Some(vec![1, 0]),
+            ],
+        )];
 
         let pop1_haplotypes = vec![
-            (0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right),
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
         ];
         let pop2_haplotypes = vec![
-            (2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right),
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
         ];
 
-        let region = QueryRegion { start: 100, end: 200 };
+        let region = QueryRegion {
+            start: 100,
+            end: 200,
+        };
 
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
@@ -792,6 +1177,8 @@ mod hudson_fst_tests {
             variants: &variants1, // Different variants!
             sample_names: &sample_names,
             sequence_length: 2,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -800,15 +1187,23 @@ mod hudson_fst_tests {
             variants: &variants2, // Different variants!
             sample_names: &sample_names,
             sequence_length: 2,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         // Direct call to per-site function should return empty vector due to guard
         let sites = calculate_hudson_fst_per_site(&pop1_context, &pop2_context, region);
-        assert!(sites.is_empty(), "Should return empty vector for incompatible variants");
+        assert!(
+            sites.is_empty(),
+            "Should return empty vector for incompatible variants"
+        );
 
         // Safe wrapper should return error
         let result = calculate_hudson_fst_for_pair_with_sites(&pop1_context, &pop2_context, region);
-        assert!(result.is_err(), "Safe wrapper should return error for incompatible variants");
+        assert!(
+            result.is_err(),
+            "Safe wrapper should return error for incompatible variants"
+        );
 
         println!("Variant compatibility guard test PASSED");
     }
@@ -816,26 +1211,44 @@ mod hudson_fst_tests {
     #[test]
     fn test_hudson_fst_missing_data() {
         // Test Hudson FST with missing genotypes
-        let variant = create_test_variant(100, vec![
-            Some(vec![0, 0]), // sample 0 - pop1
-            None,             // sample 1 - pop1 (missing)
-            Some(vec![1, 1]), // sample 2 - pop2
-            Some(vec![1, 1]), // sample 3 - pop2
-        ]);
+        let variant = create_test_variant(
+            100,
+            vec![
+                Some(vec![0, 0]), // sample 0 - pop1
+                None,             // sample 1 - pop1 (missing)
+                Some(vec![1, 1]), // sample 2 - pop2
+                Some(vec![1, 1]), // sample 3 - pop2
+            ],
+        );
 
-        let pop1_haps = vec![(0, HaplotypeSide::Left), (0, HaplotypeSide::Right),
-                            (1, HaplotypeSide::Left), (1, HaplotypeSide::Right)];
-        let pop2_haps = vec![(2, HaplotypeSide::Left), (2, HaplotypeSide::Right),
-                            (3, HaplotypeSide::Left), (3, HaplotypeSide::Right)];
+        let pop1_haps = vec![
+            (0, HaplotypeSide::Left),
+            (0, HaplotypeSide::Right),
+            (1, HaplotypeSide::Left),
+            (1, HaplotypeSide::Right),
+        ];
+        let pop2_haps = vec![
+            (2, HaplotypeSide::Left),
+            (2, HaplotypeSide::Right),
+            (3, HaplotypeSide::Left),
+            (3, HaplotypeSide::Right),
+        ];
 
-        let sample_names = vec!["s1".to_string(), "s2".to_string(), "s3".to_string(), "s4".to_string()];
-        
+        let sample_names = vec![
+            "s1".to_string(),
+            "s2".to_string(),
+            "s3".to_string(),
+            "s4".to_string(),
+        ];
+
         let pop1_context = PopulationContext {
             id: PopulationId::HaplotypeGroup(0),
             haplotypes: pop1_haps,
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let pop2_context = PopulationContext {
@@ -844,21 +1257,34 @@ mod hudson_fst_tests {
             variants: &[variant.clone()],
             sample_names: &sample_names,
             sequence_length: 1000,
+            dense_genotypes: None,
+            dense_summary: None,
         };
 
         let result = calculate_hudson_fst_for_pair(&pop1_context, &pop2_context);
-        assert!(result.is_ok(), "Hudson FST calculation with missing data failed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Hudson FST calculation with missing data failed: {:?}",
+            result.err()
+        );
 
         let outcome = result.unwrap();
         println!("Missing data FST: {:?}", outcome.fst);
-        
+
         // Should still calculate FST using available data
-        assert!(outcome.fst.is_some(), "FST should be calculated despite missing data");
-        
+        assert!(
+            outcome.fst.is_some(),
+            "FST should be calculated despite missing data"
+        );
+
         if let Some(fst) = outcome.fst {
-            // With remaining data (pop1: 2 haplotypes all 0, pop2: 4 haplotypes all 1), 
+            // With remaining data (pop1: 2 haplotypes all 0, pop2: 4 haplotypes all 1),
             // should still show strong structure
-            assert!(fst > 0.5, "FST {} should be high with remaining structured data", fst);
+            assert!(
+                fst > 0.5,
+                "FST {} should be high with remaining structured data",
+                fst
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- aggregate Hudson numerator, denominator, π, and Dxy contributions in one dense pass so downstream callers can reuse shared totals
- teach `calculate_hudson_fst_for_pair_core` to consume the cached summary, avoiding redundant π/Dxy scans and keeping error handling for empty haplotype groups
- regenerate the Python benchmark suite, showing ferromic now beats scikit-allel across every dataset and statistic

## Testing
- cargo check
- cargo test
- pytest src/pybenches/test_population_statistics_benchmarks.py --benchmark-json=bench.json

------
https://chatgpt.com/codex/tasks/task_e_68cdb702ca54832ea0e899c2f075b56d