### PR TITLE
Fix global progress counters to reflect region counts

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -1770,11 +1770,10 @@ fn process_chromosome_entries(
         );
     }
 
-    finish_entry_progress(&format!(
-        "Processed {} regions on chr{}",
+    finish_entry_progress(
+        &format!("Processed {} regions on chr{}", entries.len(), chr),
         entries.len(),
-        chr
-    ));
+    );
 
     display_status_box(StatusBox {
         title: format!("Chromosome {} Statistics", chr),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1252,7 +1252,6 @@ fn calculate_pi_from_summary_with_precomputed(
         sum
     };
 
-
     sum_pi / seq_length as f64
 }
 
@@ -1269,7 +1268,6 @@ fn aggregate_hudson_components_from_summaries(
     pop1: &DensePopulationSummary,
     pop2: &DensePopulationSummary,
 ) -> HudsonSummaryTotals {
-
     let len = pop1.alt_counts().len().min(pop2.alt_counts().len());
     let alt1 = pop1.alt_counts();
     let alt2 = pop2.alt_counts();
@@ -1334,7 +1332,6 @@ fn aggregate_hudson_components_from_summaries(
     }
 
     totals
-
 }
 
 fn hudson_component_sums(sites: &[SiteFstHudson]) -> (f64, f64) {
@@ -3128,7 +3125,6 @@ fn calculate_hudson_fst_for_pair_core<'a>(
         summary_totals = Some(totals);
         summary_refs = Some((summary1, summary2));
         (totals.numerator_sum, totals.denominator_sum)
-
     } else if let Some(matrix) = dense_shared {
         if pop1_context.variants.is_empty() {
             (0.0, 0.0)
@@ -3200,7 +3196,6 @@ fn calculate_hudson_fst_for_pair_core<'a>(
         let dxy_result = calculate_d_xy_hudson(pop1_context, pop2_context)?;
         (pi1_raw, pi2_raw, dxy_result)
     };
-
 
     let pi1_opt = if pi1_raw.is_finite() {
         Some(pi1_raw)


### PR DESCRIPTION
## Summary
- count completed regions when updating the global progress tracker so the overall bar matches actual work
- reset timing state per entry and feed region counts from chromosome processing to the tracker for accurate status messaging
- run rustfmt cleanups that removed stray blank lines in the stats module

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf180b9854832eaa4a888b30dce46f