### PR TITLE
Optimize dense PCA paths and Python bindings

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1108,6 +1108,7 @@ impl DenseMembership {
             }
         }
 
+        offsets.sort_unstable();
         Self { offsets }
     }
 
@@ -1166,20 +1167,28 @@ pub fn build_dense_population_summary(
     let mut called_counts = vec![0u32; variant_count];
 
     if let Some(bits) = matrix.missing_slice() {
-        for variant_idx in 0..variant_count {
-            let base = variant_idx * stride;
-            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
-            alt_counts[variant_idx] = alt as u32;
-            called_counts[variant_idx] = called as u32;
-        }
+        alt_counts
+            .par_iter_mut()
+            .zip_eq(called_counts.par_iter_mut())
+            .enumerate()
+            .for_each(|(variant_idx, (alt_slot, called_slot))| {
+                let base = variant_idx * stride;
+                let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+                *alt_slot = alt as u32;
+                *called_slot = called as u32;
+            });
     } else {
         let total = offsets.len() as u32;
-        for variant_idx in 0..variant_count {
-            let base = variant_idx * stride;
-            let alt = dense_sum_alt_no_missing(data, base, offsets);
-            alt_counts[variant_idx] = alt as u32;
-            called_counts[variant_idx] = total;
-        }
+        alt_counts
+            .par_iter_mut()
+            .zip_eq(called_counts.par_iter_mut())
+            .enumerate()
+            .for_each(|(variant_idx, (alt_slot, called_slot))| {
+                let base = variant_idx * stride;
+                let alt = dense_sum_alt_no_missing(data, base, offsets);
+                *alt_slot = alt as u32;
+                *called_slot = total;
+            });
     }
 
     DensePopulationSummary {
@@ -3478,56 +3487,61 @@ fn count_segregating_sites_dense(
     }
     let stride = matrix.stride();
     let data = matrix.data();
-    let mut segregating = 0usize;
+    let variant_count = matrix.variant_count();
 
     if let Some(bits) = matrix.missing_slice() {
-        for variant_idx in 0..matrix.variant_count() {
-            let base = variant_idx * stride;
-            let mut first: Option<u8> = None;
-            let mut polymorphic = false;
-            for &offset in offsets {
-                let idx = base + offset;
-                if dense_missing(bits, idx) {
-                    continue;
-                }
-                let allele = data[idx];
-                if let Some(value) = first {
-                    if allele != value {
-                        polymorphic = true;
-                        break;
+        (0..variant_count)
+            .into_par_iter()
+            .map(|variant_idx| {
+                let base = variant_idx * stride;
+                let mut first: Option<u8> = None;
+                let mut polymorphic = false;
+                unsafe {
+                    let ptr = data.as_ptr().add(base);
+                    for &offset in offsets {
+                        let idx = base + offset;
+                        if dense_missing(bits, idx) {
+                            continue;
+                        }
+                        let allele = *ptr.add(offset);
+                        match first {
+                            None => first = Some(allele),
+                            Some(value) if value != allele => {
+                                polymorphic = true;
+                                break;
+                            }
+                            _ => {}
+                        }
                     }
-                } else {
-                    first = Some(allele);
                 }
-            }
-            if polymorphic {
-                segregating += 1;
-            }
-        }
+                usize::from(polymorphic)
+            })
+            .sum()
     } else {
-        for variant_idx in 0..matrix.variant_count() {
-            let base = variant_idx * stride;
-            let mut first: Option<u8> = None;
-            let mut polymorphic = false;
-            for &offset in offsets {
-                let idx = base + offset;
-                let allele = data[idx];
-                if let Some(value) = first {
-                    if allele != value {
-                        polymorphic = true;
-                        break;
+        (0..variant_count)
+            .into_par_iter()
+            .map(|variant_idx| {
+                let base = variant_idx * stride;
+                let mut first: Option<u8> = None;
+                let mut polymorphic = false;
+                unsafe {
+                    let ptr = data.as_ptr().add(base);
+                    for &offset in offsets {
+                        let allele = *ptr.add(offset);
+                        match first {
+                            None => first = Some(allele),
+                            Some(value) if value != allele => {
+                                polymorphic = true;
+                                break;
+                            }
+                            _ => {}
+                        }
                     }
-                } else {
-                    first = Some(allele);
                 }
-            }
-            if polymorphic {
-                segregating += 1;
-            }
-        }
+                usize::from(polymorphic)
+            })
+            .sum()
     }
-
-    segregating
 }
 
 fn count_segregating_sites_dense_biallelic(
@@ -3541,27 +3555,27 @@ fn count_segregating_sites_dense_biallelic(
     let stride = matrix.stride();
     let data = matrix.data();
     let total = offsets.len();
-    let mut segregating = 0usize;
+    let variant_count = matrix.variant_count();
 
     if let Some(bits) = matrix.missing_slice() {
-        for variant_idx in 0..matrix.variant_count() {
-            let base = variant_idx * stride;
-            let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
-            if called >= 2 && alt > 0 && alt < called {
-                segregating += 1;
-            }
-        }
+        (0..variant_count)
+            .into_par_iter()
+            .map(|variant_idx| {
+                let base = variant_idx * stride;
+                let (called, alt) = dense_sum_alt_with_missing(data, base, offsets, bits);
+                usize::from(called >= 2 && alt > 0 && alt < called)
+            })
+            .sum()
     } else {
-        for variant_idx in 0..matrix.variant_count() {
-            let base = variant_idx * stride;
-            let alt = dense_sum_alt_no_missing(data, base, offsets);
-            if alt > 0 && alt < total {
-                segregating += 1;
-            }
-        }
+        (0..variant_count)
+            .into_par_iter()
+            .map(|variant_idx| {
+                let base = variant_idx * stride;
+                let alt = dense_sum_alt_no_missing(data, base, offsets);
+                usize::from(alt > 0 && alt < total)
+            })
+            .sum()
     }
-
-    segregating
 }
 
 // Calculate pairwise differences and comparable sites between all sample pairs


### PR DESCRIPTION
## Summary
- accelerate dense PCA preparation by operating on contiguous genotype slices, including early sample validation and pointer-based matrix writes
- parallelize dense population summaries by sorting haplotype offsets and using rayon to aggregate allele counts quickly
- streamline the Python interface by releasing the GIL around heavy statistics, improving PCA array transfers, and ensuring population helpers return results via `PyResult`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68cfa71dda34832ea1751df540193d41