### PR TITLE
Ensure scikit-allel benchmarks always run

### DIFF
--- a/src/pybenches/test_population_pca_benchmarks.py
+++ b/src/pybenches/test_population_pca_benchmarks.py
@@ -11,7 +11,14 @@ import pytest
 
 import ferromic as fm
 
-allel = pytest.importorskip("allel")
+try:  # scikit-allel is required so both PCA implementations are benchmarked.
+    import allel
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "scikit-allel must be installed for PCA benchmarks. Install ferromic "
+        "with the 'test' extra (pip install .[test]) to compare against "
+        "scikit-allel."
+    ) from exc
 
 from pytest_benchmark.fixture import BenchmarkFixture
 

--- a/src/pybenches/test_population_statistics_benchmarks.py
+++ b/src/pybenches/test_population_statistics_benchmarks.py
@@ -13,7 +13,14 @@ import pytest
 
 import ferromic as fm
 
-allel = pytest.importorskip("allel")
+try:  # scikit-allel is required for fair benchmark comparisons.
+    import allel
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "scikit-allel must be installed for population statistic benchmarks. "
+        "Install ferromic with the 'test' extra (pip install .[test]) so both "
+        "implementations are exercised."
+    ) from exc
 
 from pytest_benchmark.fixture import BenchmarkFixture
 from pytest_benchmark.stats import Metadata


### PR DESCRIPTION
## Summary
- require scikit-allel to be installed when collecting the population statistics and PCA benchmark suites
- provide actionable error messages so benchmark runs fail fast instead of being silently skipped

## Testing
- pytest src/pybenches/test_population_statistics_benchmarks.py::test_benchmark_segregating_sites --maxfail=1 -q
- pytest src/pybenches/test_population_pca_benchmarks.py -k benchmark --maxfail=1 -q

------
https://chatgpt.com/codex/tasks/task_e_68cfa4500fd4832eb000da0527e8ba69