### PR TITLE
Remove vendored OpenSSL dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,6 @@ chrono = "0.4.41"
 glob = "0.3.2"
 ndarray = "0.16.1"
 nalgebra = "0.33"
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9.109", features = ["vendored"] }
-
-[build-dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9.109", features = ["vendored"] }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## Summary
- remove the vendored OpenSSL crates from the project manifest so system OpenSSL is no longer bundled

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d1b1df7824832e972061d36e907b36