### PR TITLE
Ensure Python benchmarks use release builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2188,6 +2188,16 @@ fn inversion_allele_frequency_py(sample_map: &PyAny) -> PyResult<Option<f64>> {
 #[pymodule]
 fn ferromic(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    let build_profile = option_env!("PROFILE").unwrap_or(if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    });
+    let opt_level =
+        option_env!("OPT_LEVEL").unwrap_or(if cfg!(debug_assertions) { "0" } else { "3" });
+    m.add("__rust_profile__", build_profile)?;
+    m.add("__rust_opt_level__", opt_level)?;
+    m.add("__debug_build__", cfg!(debug_assertions))?;
     m.add_class::<Population>()?;
     m.add_class::<PairwiseDifference>()?;
     m.add_class::<ChromosomePcaResult>()?;

--- a/src/pybenches/conftest.py
+++ b/src/pybenches/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest helpers enforcing optimal Ferromic build settings for benchmarks."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import ferromic as fm
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise pytest.UsageError(
+        "Ferromic's Python benchmarks require the extension module to be installed. "
+        "Build it with `maturin develop --release` before running these benchmarks."
+    ) from exc
+
+RUST_PROFILE = getattr(fm, "__rust_profile__", None)
+RUST_OPT_LEVEL = getattr(fm, "__rust_opt_level__", None)
+
+
+def _profile_description() -> str:
+    if RUST_PROFILE is None:
+        return "an unknown profile"
+    if RUST_OPT_LEVEL is None:
+        return f"the '{RUST_PROFILE}' profile"
+    return f"the '{RUST_PROFILE}' profile (opt-level={RUST_OPT_LEVEL!r})"
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:  # pragma: no cover - exercised via pytest
+    if RUST_PROFILE != "release":
+        raise pytest.UsageError(
+            "Ferromic's Python benchmarks require the Rust extension module to be built "
+            "with Cargo's release profile for meaningful performance comparisons. "
+            "Reinstall Ferromic with `maturin develop --release` (or an equivalent) before rerunning "
+            f"these benchmarks. Detected {_profile_description()}."
+        )
+
+
+__all__ = ["pytest_sessionstart"]


### PR DESCRIPTION
## Summary
- expose the Rust build profile, opt level, and debug state to the pyo3 module
- gate the Python benchmark suite behind a pytest hook that requires a release build

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d1e145a848832ea0d82b6ddf5c966d