### PR TITLE
Make benchmark tests a package

### DIFF
--- a/src/pybenches/__init__.py
+++ b/src/pybenches/__init__.py
@@ -1,0 +1,7 @@
+"""Test benchmarks package for Pytest discovery.
+
+Adding this module allows benchmark tests to use package-relative imports
+when executed by pytest, which treats the directory as a package once an
+``__init__`` module is present.
+"""
+


### PR DESCRIPTION
## Summary
- add an __init__ module to the pybenches test directory so pytest treats it as a package

## Testing
- pytest src/pybenches --benchmark-only --benchmark-json bench-results.json *(fails: Ferromic's Python benchmarks require the extension module to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fcd6f7e8832ea6b3c3d3a2cb6874