### PR TITLE
Restore efficient_pca-backed PCA implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,10 @@ terminal_size = "0.4.2"
 chrono = "0.4.41"
 glob = "0.3.2"
 ndarray = "0.16.1"
-nalgebra = "0.33"
+efficient_pca = { version = "*", default-features = false, features = ["backend_faer"] }
+
+[patch.crates-io]
+efficient_pca = { git = "https://github.com/SauersML/efficient_pca" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## Summary
- restore the original efficient_pca-based PCA workflow in `src/pca.rs`
- remove the nalgebra dependency and add the efficient_pca crate in `Cargo.toml`
- track the upstream `efficient_pca` crate directly from its repository without pinning to a specific revision

## Testing
- `cargo check` *(fails because the upstream `efficient_pca` crate now enables `#![feature(portable_simd)]`, which requires a nightly toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68d2056ae108832eb6ce8f714365d9db