### PR TITLE
Restore efficient_pca-backed PCA implementation and require nightly Rust

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install build dependencies
         if: ${{ matrix.platform.target == 'x86_64' }}
         run: |
@@ -66,6 +66,7 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
+          rust-toolchain: nightly
           before-script-linux: |
             if command -v microdnf >/dev/null 2>&1; then
               microdnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
@@ -110,6 +111,7 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
+          rust-toolchain: nightly
           before-script-linux: |
             if command -v microdnf >/dev/null 2>&1; then
               microdnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
@@ -160,6 +162,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -184,6 +187,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          rust-toolchain: nightly
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -216,3 +220,4 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+          rust-toolchain: nightly

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Create virtual environment
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
       - name: Build
         run: cargo build --verbose --release
       - name: Test
@@ -72,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,10 @@ terminal_size = "0.4.2"
 chrono = "0.4.41"
 glob = "0.3.2"
 ndarray = "0.16.1"
-nalgebra = "0.33"
+efficient_pca = { version = "*", default-features = false, features = ["backend_faer"] }
+
+[patch.crates-io]
+efficient_pca = { git = "https://github.com/SauersML/efficient_pca" }
 
 [profile.release]
 lto = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
## Summary
- restore the original efficient_pca-based PCA workflow in `src/pca.rs`
- remove the nalgebra dependency and add the efficient_pca crate in `Cargo.toml`
- track the upstream `efficient_pca` crate directly from its repository without pinning to a specific revision
- require the nightly Rust toolchain locally and in all GitHub Actions workflows so SIMD-enabled efficient_pca builds succeed

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d2056ae108832eb6ce8f714365d9db