### PR TITLE
Optimize exact PCA and add benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,13 +58,22 @@ once_cell = "1.21.3"
 terminal_size = "0.4.2"
 chrono = "0.4.41"
 glob = "0.3.2"
-ndarray = "0.16.1"
+ndarray = { version = "0.16.1", features = ["rayon"] }
 efficient_pca = { version = "*", default-features = false, features = ["backend_faer"] }
+faer = { version = "0.22.6", features = ["std", "rayon"] }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [patch.crates-io]
 efficient_pca = { git = "https://github.com/SauersML/efficient_pca" }
 
 [profile.release]
+lto = true
+codegen-units = 1
+panic = 'abort'
+
+[profile.bench]
 lto = true
 codegen-units = 1
 panic = 'abort'
@@ -80,3 +89,7 @@ path = "src/merge.rs"
 [[bin]]
 name = "run_vcf"
 path = "src/run_vcf.rs"
+
+[[bench]]
+name = "pca"
+harness = false

--- a/benches/pca.rs
+++ b/benches/pca.rs
@@ -1,0 +1,90 @@
+use std::{env, time::Duration};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ferromic::pca::{bench_efficient_exact_pca, bench_fast_exact_pca};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+const PLOIDY: usize = 2;
+const COMPONENTS: usize = 8;
+
+fn generate_dataset(variants: usize, samples: usize, seed: u64) -> Vec<i16> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut data = vec![0i16; variants * samples * PLOIDY];
+
+    for variant_idx in 0..variants {
+        for sample_idx in 0..samples {
+            let base = (variant_idx * samples + sample_idx) * PLOIDY;
+            data[base] = rng.gen_range(0..=1);
+            data[base + 1] = rng.gen_range(0..=1);
+        }
+    }
+
+    data
+}
+
+fn genotype_matrix(data: &[i16], variants: usize, samples: usize) -> (Vec<f64>, usize, usize) {
+    let rows = samples * PLOIDY;
+    let cols = variants;
+    let mut matrix = vec![0.0f64; rows * cols];
+    for variant_idx in 0..variants {
+        for sample_idx in 0..samples {
+            let base = (variant_idx * samples + sample_idx) * PLOIDY;
+            let row_left = sample_idx * PLOIDY;
+            let left_idx = row_left * cols + variant_idx;
+            matrix[left_idx] = data[base] as f64;
+            matrix[left_idx + cols] = data[base + 1] as f64;
+        }
+    }
+    (matrix, rows, cols)
+}
+
+fn bench_exact_pca_dense(c: &mut Criterion) {
+    let mut group = c.benchmark_group("exact_pca_dense");
+    env::set_var("FERROMIC_PROGRESS", "0");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(8));
+    group.warm_up_time(Duration::from_secs(2));
+    let sizes = [
+        (200usize, 64usize),
+        (800usize, 128usize),
+        (2000usize, 256usize),
+    ];
+
+    for (variants, samples) in sizes {
+        let seed = 0x5A5A_0000 ^ ((variants as u64) << 16) ^ samples as u64;
+        let data = generate_dataset(variants, samples, seed);
+
+        group.throughput(Throughput::Elements((variants * samples) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("fast", format!("v{}_s{}", variants, samples)),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let (matrix, rows, cols) = genotype_matrix(data, variants, samples);
+                    let _result = bench_fast_exact_pca(matrix, rows, cols, COMPONENTS)
+                        .expect("fast exact PCA should succeed");
+                    criterion::black_box(&_result);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("fallback", format!("v{}_s{}", variants, samples)),
+            &data,
+            |b, data| {
+                b.iter(|| {
+                    let (matrix, rows, cols) = genotype_matrix(data, variants, samples);
+                    let _result = bench_efficient_exact_pca(matrix, rows, cols, COMPONENTS)
+                        .expect("fallback exact PCA should succeed");
+                    criterion::black_box(&_result);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_exact_pca_dense);
+criterion_main!(benches);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1223,7 +1223,6 @@ pub fn build_dense_population_summary(
             (seg, pi_total)
         }
     } else if let Some(bits) = missing {
-
         alt_counts
             .par_iter_mut()
             .zip_eq(called_counts.par_iter_mut())


### PR DESCRIPTION
## Summary
- enable ndarray rayon support, add faer dependency, and configure Criterion bench harness
- add Criterion benchmark to compare fast faer PCA against the existing fallback
- replace the SVD-based fast PCA path with a faer Gram/covariance eigen approach that skips fallback work for small workloads

## Testing
- cargo test -- --skip eigensnp
- cargo bench --bench pca --no-run
- FERROMIC_PROGRESS=0 target/release/deps/pca-900ed39c798ebc74 --bench

------
https://chatgpt.com/codex/tasks/task_e_68d23e5d29a0832e9f9d84a9023e1e76