### PR TITLE
Fix 2024 edition lint regressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+// NOTE: The current PyO3 code generation (v0.18) performs raw argument extraction
+// through helper functions that remain `unsafe` under the Rust 2024 lint regime.
+// Those calls originate in macro expansions that we cannot update locally, so we
+// suppress the lint at the crate level to keep the Python bindings compiling
+// cleanly while we remain on this PyO3 version. When PyO3 releases 2024-ready
+// macros the attribute can be revisited.
+//
 //! Ergonomic Python bindings for Ferromic's population genetics toolkit.
 //!
 //! The bindings expose a high-level, well-documented API that mirrors the core

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -605,7 +605,7 @@ pub fn read_reference_sequence(
     let invalid_chars: Vec<(usize, u8)> = sequence
         .iter()
         .enumerate()
-        .filter(|(_, &b)| !matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'N'))
+        .filter(|&(_, &b)| !matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'N'))
         .take(10)
         .map(|(i, &b)| (i, b))
         .collect();

--- a/src/pca.rs
+++ b/src/pca.rs
@@ -790,7 +790,7 @@ pub fn bench_efficient_exact_pca(
 #[inline(always)]
 unsafe fn read_unchecked<T: Copy>(ptr: *const T) -> T {
     debug_assert!(!ptr.is_null());
-    *ptr
+    unsafe { *ptr }
 }
 
 fn diag_to_vec(diag: DiagRef<'_, f64>) -> Vec<f64> {


### PR DESCRIPTION
## Summary
- allow `unsafe_op_in_unsafe_fn` at the crate root with documentation so PyO3-generated shims continue compiling on Rust 2024
- make the reference-sequence validator explicit about tuple references to satisfy the new match ergonomics rules
- wrap the raw pointer dereference helper in an `unsafe` block to comply with Rust 2024 unsafe-op requirements

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d3bfa324f4832eb7c5ecfa7be8222a