### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,156 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'release*'
+      - 'py-*'
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform: >-
+          ${{ fromJson('[{"runner":"ubuntu-22.04","target":"x86_64","openblas_target":"SANDYBRIDGE"},{"runner":"ubuntu-22.04","target":"x86","openblas_target":"ATOM"},{"runner":"ubuntu-22.04","target":"aarch64","openblas_target":"ARMV8"},{"runner":"ubuntu-22.04","target":"armv7","openblas_target":"ARMV7"},{"runner":"ubuntu-22.04","target":"ppc64le","openblas_target":"POWER9"}]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        if: ${{ matrix.platform.target == 'x86_64' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gfortran perl wget
+          perl -MIPC::Cmd -e1 >/dev/null 2>&1 || (wget -O - https://cpanmin.us | perl - --notest IPC::Cmd)
+      - name: Publish Linux wheels to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          OPENSSL_STATIC: 1
+          OPENSSL_VENDORED: 1
+          OPENBLAS_TARGET: ${{ matrix.platform.openblas_target }}
+        with:
+          command: publish
+          target: ${{ matrix.platform.target }}
+          args: --release --skip-existing --find-interpreter
+          manylinux: auto
+          rust-toolchain: nightly
+          sccache: false
+          before-script-linux: |
+            if command -v microdnf >/dev/null 2>&1; then
+              microdnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v dnf >/dev/null 2>&1; then
+              dnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v yum >/dev/null 2>&1; then
+              yum install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update
+              apt-get install -y build-essential gfortran perl wget
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache build-base gfortran perl perl-utils wget
+            fi
+            perl -MIPC::Cmd -e1 >/dev/null 2>&1 || (wget -O - https://cpanmin.us | perl - --notest IPC::Cmd)
+
+  musllinux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform: >-
+          ${{ fromJson('[{"runner":"ubuntu-22.04","target":"x86_64","openblas_target":"SANDYBRIDGE"},{"runner":"ubuntu-22.04","target":"x86","openblas_target":"ATOM"},{"runner":"ubuntu-22.04","target":"aarch64","openblas_target":"ARMV8"},{"runner":"ubuntu-22.04","target":"armv7","openblas_target":"ARMV7"}]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Publish musllinux wheels to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          OPENSSL_STATIC: 1
+          OPENSSL_VENDORED: 1
+          OPENBLAS_TARGET: ${{ matrix.platform.openblas_target }}
+        with:
+          command: publish
+          target: ${{ matrix.platform.target }}
+          args: --release --skip-existing --find-interpreter
+          manylinux: musllinux_1_2
+          rust-toolchain: nightly
+          sccache: false
+          before-script-linux: |
+            if command -v microdnf >/dev/null 2>&1; then
+              microdnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v dnf >/dev/null 2>&1; then
+              dnf install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v yum >/dev/null 2>&1; then
+              yum install -y gcc gcc-c++ gcc-gfortran make perl perl-IPC-Cmd wget
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update
+              apt-get install -y build-essential gfortran perl wget
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache build-base gfortran perl perl-utils wget
+            fi
+            perl -MIPC::Cmd -e1 >/dev/null 2>&1 || (wget -O - https://cpanmin.us | perl - --notest IPC::Cmd)
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform: >-
+          ${{ fromJson('[{"runner":"windows-latest","target":"x64","vcpkg_triplet":"x64-windows"},{"runner":"windows-latest","target":"x86","vcpkg_triplet":"x86-windows"}]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          architecture: ${{ matrix.platform.target }}
+      - name: Install OpenBLAS dependencies
+        shell: pwsh
+        run: |
+          $vcpkgRoot = Join-Path $Env:USERPROFILE "vcpkg"
+          if (-Not (Test-Path $vcpkgRoot)) {
+            git clone https://github.com/microsoft/vcpkg.git $vcpkgRoot
+            & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
+          }
+          & (Join-Path $vcpkgRoot "vcpkg.exe") install openblas --triplet ${{ matrix.platform.vcpkg_triplet }}
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKG_DEFAULT_TRIPLET=${{ matrix.platform.vcpkg_triplet }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Publish Windows wheels to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: publish
+          target: ${{ matrix.platform.target }}
+          args: --release --skip-existing --find-interpreter
+          rust-toolchain: nightly
+          sccache: false
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform: >-
+          ${{ fromJson('[{"runner":"macos-13","target":"x86_64"},{"runner":"macos-14","target":"aarch64"}]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Publish macOS wheels to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: publish
+          target: ${{ matrix.platform.target }}
+          args: --release --skip-existing --find-interpreter
+          rust-toolchain: nightly
+          sccache: false


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow that builds wheels for Linux, musllinux, Windows, and macOS using PyO3/maturin-action
- configure the workflow to publish the generated artifacts directly to PyPI with the provided token

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3ca227598832eb4a44a85347dfb2f