### PR TITLE
Benchmark imputed inversion dosages vs scoreInvHap (Reviewer 2 #3)

### DIFF
--- a/.github/workflows/scoreinvhap_concordance.yml
+++ b/.github/workflows/scoreinvhap_concordance.yml
@@ -1,0 +1,177 @@
+name: ScoreInvHap Concordance Benchmark
+
+# Reviewer 2, comment 3: benchmark our imputed inversion dosages against the
+# published tool scoreInvHap (Ruiz-Arenas et al., PLOS Genetics 2019) for the
+# 8p23.1 and 17q21.31 inversions in a large public cohort (1000 Genomes).
+#
+# Two methods are run on the SAME 1000 Genomes individuals:
+#   * scoreInvHap  -> uses its shipped 1000G-phase3 (GRCh37) reference objects,
+#                     so it is fed the GRCh37 phase-3 VCFs (its native build).
+#   * our PLS models (data/models) -> trained on GRCh38, so they are fed the
+#                     GRCh38 high-coverage phased VCFs (their native build).
+# We then intersect on the shared sample IDs and compute per-sample concordance.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system tools (bcftools, tabix, plink2)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y bcftools tabix
+          # plink2
+          wget -q https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_x86_64_20240625.zip -O plink2.zip || \
+          wget -q https://s3.amazonaws.com/plink2-assets/plink2_linux_x86_64_latest.zip -O plink2.zip
+          unzip -o plink2.zip
+          sudo mv plink2 /usr/local/bin/
+          plink2 --version
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy pandas scipy scikit-learn joblib matplotlib bed_reader requests tqdm
+
+      # --------------------------------------------------------------------
+      # 1000 Genomes region subsets. We pull only the inversion ROIs via tabix
+      # from the remote bgzipped+indexed VCFs (no full-chromosome downloads).
+      # --------------------------------------------------------------------
+      - name: Subset GRCh38 high-coverage VCFs (for OUR models)
+        run: |
+          set -euo pipefail
+          B38=http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/working/20220422_3202_phased_SNV_INDEL_SV
+          # GRCh38 ROIs covering each model's SNP span (with margin).
+          # 8p23.1 model SNPs span chr8:8.23-12.65 Mb ; 17q21.31 span chr17:45.57-46.28 Mb
+          tabix -h ${B38}/1kGP_high_coverage_Illumina.chr8.filtered.SNV_INDEL_SV_phased_panel.vcf.gz \
+            chr8:8000000-12800000 | bgzip > b38_chr8.vcf.gz
+          tabix -h ${B38}/1kGP_high_coverage_Illumina.chr17.filtered.SNV_INDEL_SV_phased_panel.vcf.gz \
+            chr17:45400000-46400000 | bgzip > b38_chr17.vcf.gz
+          for f in b38_chr8 b38_chr17; do
+            echo "== $f =="; bcftools index -t ${f}.vcf.gz
+            echo "variants: $(bcftools view -H ${f}.vcf.gz | wc -l) ; samples: $(bcftools query -l ${f}.vcf.gz | wc -l)"
+          done
+
+      - name: Subset GRCh37 phase-3 VCFs (for scoreInvHap)
+        run: |
+          set -euo pipefail
+          B37=http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502
+          # GRCh37 ROIs (8p23.1 ~ chr8:8-12 Mb ; 17q21.31 ~ chr17:43.0-44.9 Mb).
+          tabix -h ${B37}/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5b.20130502.genotypes.vcf.gz \
+            8:7000000-13000000 | bgzip > b37_chr8.vcf.gz
+          tabix -h ${B37}/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5b.20130502.genotypes.vcf.gz \
+            17:42000000-45500000 | bgzip > b37_chr17.vcf.gz
+          for f in b37_chr8 b37_chr17; do
+            echo "== $f =="; bcftools index -t ${f}.vcf.gz
+            echo "variants: $(bcftools view -H ${f}.vcf.gz | wc -l) ; samples: $(bcftools query -l ${f}.vcf.gz | wc -l)"
+          done
+
+      # --------------------------------------------------------------------
+      # OUR imputation pipeline on GRCh38 data.
+      # --------------------------------------------------------------------
+      - name: Build PLINK bed for our models (GRCh38)
+        run: |
+          set -euo pipefail
+          # Merge the two ROI VCFs, normalise to biallelic, write PLINK1 bed.
+          bcftools concat -a b38_chr8.vcf.gz b38_chr17.vcf.gz -Oz -o b38_merged.vcf.gz
+          bcftools index -t b38_merged.vcf.gz
+          plink2 --vcf b38_merged.vcf.gz \
+            --max-alleles 2 --snps-only just-acgt \
+            --set-all-var-ids '@:#' \
+            --make-bed --out subset
+          wc -l subset.bim
+          head -3 subset.fam
+
+      - name: Prepare genotype matrices and run our inference
+        env:
+          PLINK_PREFIX: subset
+          OUTPUT_DIR: genotype_matrices
+          MODEL_SOURCE_DIR: data/models
+        run: |
+          set -euo pipefail
+          python imputation/prepare_data_for_infer.py
+          ls -la genotype_matrices | head
+          # Bring pls_patch onto the path so joblib can unpickle the models.
+          cp imputation/pls_patch.py .
+          python scoreinvhap_benchmark/infer_dosage_public.py \
+            chr8-7301025-INV-5297356 our_8p23.tsv
+          python scoreinvhap_benchmark/infer_dosage_public.py \
+            chr17-45585160-INV-706887 our_17q21.tsv
+
+      # --------------------------------------------------------------------
+      # scoreInvHap on GRCh37 data.
+      # --------------------------------------------------------------------
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Install scoreInvHap (Bioconductor)
+        run: |
+          set -euo pipefail
+          Rscript -e 'install.packages("BiocManager", repos="https://cloud.r-project.org")'
+          Rscript -e 'BiocManager::install(c("scoreInvHap","VariantAnnotation","GenomicRanges"), update=FALSE, ask=FALSE)'
+          Rscript -e 'library(scoreInvHap); cat("scoreInvHap OK\n")'
+
+      - name: Run scoreInvHap genotyping
+        run: |
+          set -euo pipefail
+          Rscript scoreinvhap_benchmark/run_scoreinvhap.R b37_chr8.vcf.gz  inv8p23.1   sih_8p23.tsv
+          Rscript scoreinvhap_benchmark/run_scoreinvhap.R b37_chr17.vcf.gz inv17q21.31 sih_17q21.tsv
+          head sih_8p23.tsv sih_17q21.tsv
+
+      # --------------------------------------------------------------------
+      # Concordance: join on shared sample IDs, compute r^2, emit TSV + PDF.
+      # --------------------------------------------------------------------
+      - name: Compute concordance
+        run: |
+          set -euo pipefail
+          mkdir -p data
+          python scoreinvhap_benchmark/compute_concordance.py \
+            --out-tsv data/scoreinvhap_concordance.tsv \
+            --out-pdf data/scoreinvhap_concordance.pdf \
+            --pair "8p23.1"   our_8p23.tsv  chr8-7301025-INV-5297356   sih_8p23.tsv \
+            --pair "17q21.31" our_17q21.tsv chr17-45585160-INV-706887  sih_17q21.tsv
+          echo "=== RESULT ==="
+          cat data/scoreinvhap_concordance.tsv
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scoreinvhap-concordance
+          path: |
+            data/scoreinvhap_concordance.tsv
+            data/scoreinvhap_concordance.pdf
+            our_8p23.tsv
+            our_17q21.tsv
+            sih_8p23.tsv
+            sih_17q21.tsv
+
+      - name: Commit results to branch
+        if: success()
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/scoreinvhap_concordance.tsv data/scoreinvhap_concordance.pdf
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Add scoreInvHap concordance benchmark outputs (Reviewer 2 #3)"
+            git push origin HEAD:${GITHUB_REF_NAME}
+          fi

--- a/.github/workflows/scoreinvhap_concordance.yml
+++ b/.github/workflows/scoreinvhap_concordance.yml
@@ -114,7 +114,9 @@ jobs:
         run: |
           set -euo pipefail
           python imputation/prepare_data_for_infer.py
-          ls -la genotype_matrices | head
+          echo "Genotype matrices for our two targets:"
+          ls -la genotype_matrices/chr8-7301025-INV-5297356.genotypes.npy \
+                 genotype_matrices/chr17-45585160-INV-706887.genotypes.npy
           # Bring pls_patch onto the path so joblib can unpickle the models.
           cp imputation/pls_patch.py .
           python scoreinvhap_benchmark/infer_dosage_public.py \

--- a/.github/workflows/scoreinvhap_concordance.yml
+++ b/.github/workflows/scoreinvhap_concordance.yml
@@ -13,6 +13,16 @@ name: ScoreInvHap Concordance Benchmark
 
 on:
   workflow_dispatch:
+  # workflow_dispatch only works once the file lands on the default branch, so
+  # we also trigger on pushes to this feature branch to exercise the benchmark
+  # from the PR before merge.
+  push:
+    branches:
+      - benchmark-scoreinvhap-concordance
+    # Avoid an infinite loop: the job commits results under data/, so ignore
+    # pushes that only touch the result files.
+    paths-ignore:
+      - 'data/scoreinvhap_concordance.*'
 
 permissions:
   contents: write

--- a/scoreinvhap_benchmark/README.md
+++ b/scoreinvhap_benchmark/README.md
@@ -1,0 +1,41 @@
+# ScoreInvHap concordance benchmark (Reviewer 2, comment 3)
+
+Benchmarks our imputed inversion dosages against the published genotyping tool
+**scoreInvHap** (Ruiz-Arenas et al., *PLOS Genetics* 2019;
+[isglobal-brge/scoreInvHap](https://github.com/isglobal-brge/scoreInvHap))
+for the two inversions scoreInvHap ships reference objects for, **8p23.1** and
+**17q21.31**, in a large public cohort (1000 Genomes).
+
+## What runs where
+
+Each method is run on its own native genome build, then the two call sets are
+intersected on the shared 1000 Genomes sample IDs:
+
+| Method | Inversion IDs | Cohort / build |
+| --- | --- | --- |
+| scoreInvHap (`inv8_001`, `inv17_007`) | 8p23.1, 17q21.31 | 1000G phase-3, GRCh37 |
+| Our PLS models (`data/models/`) | `chr8-7301025-INV-5297356`, `chr17-45585160-INV-706887` | 1000G high-coverage, GRCh38 |
+
+Inversion IDs were verified by coordinate against `data/inv_properties.tsv`:
+8p23.1 = `chr8-7301025-INV-5297356` (chr8:7,301,024-12,598,379) and
+17q21.31 = `chr17-45585160-INV-706887` (chr17:45,585,159-46,292,045).
+
+## Files
+
+- `run_scoreinvhap.R` — genotype an inversion with scoreInvHap from a VCF.
+- `infer_dosage_public.py` — run our trained models on the prepared genotype
+  matrices, filling missing genotypes with the per-SNP cohort mean (no
+  All-of-Us ancestry priors; public data only).
+- `compute_concordance.py` — join both methods per sample; emit `r`, `r²`,
+  Spearman ρ, hard-call concordance and inverted-allele frequencies, plus a
+  scatter PDF.
+
+The whole benchmark is wired as
+`.github/workflows/scoreinvhap_concordance.yml` and writes
+`data/scoreinvhap_concordance.tsv` and `data/scoreinvhap_concordance.pdf`.
+
+## Reviewer expectations
+
+8p23.1 is expected to impute near-perfectly (r² ≈ 1) and 17q21.31 has perfect
+tag SNPs, so both inversions should show very high concordance with
+scoreInvHap.

--- a/scoreinvhap_benchmark/compute_concordance.py
+++ b/scoreinvhap_benchmark/compute_concordance.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Compare our imputed inversion dosages against scoreInvHap genotypes.
+
+For each inversion we join the two per-sample tables on SampleID and compute:
+  - Pearson r and r^2 between our continuous dosage and the scoreInvHap dosage
+  - Spearman rho (rank concordance, robust to the discrete scoreInvHap calls)
+  - hard-call concordance: fraction of samples where round(our dosage) equals
+    the scoreInvHap integer genotype
+  - allele-frequency of the inverted allele under each method
+
+Emits a tidy comparison TSV and a scatter PDF (one panel per inversion).
+
+Usage:
+  compute_concordance.py --out-tsv data/scoreinvhap_concordance.tsv \
+      --out-pdf data/scoreinvhap_concordance.pdf \
+      --pair NAME OUR_TSV OUR_COL SIH_TSV [--pair ...]
+"""
+import argparse
+import sys
+
+import numpy as np
+import pandas as pd
+from scipy.stats import pearsonr, spearmanr
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def load_pair(name, our_tsv, our_col, sih_tsv):
+    our = pd.read_csv(our_tsv, sep="\t", dtype={"SampleID": str})
+    sih = pd.read_csv(sih_tsv, sep="\t", dtype={"SampleID": str})
+    if our_col not in our.columns:
+        # tolerate the model id being the only non-SampleID column
+        cols = [c for c in our.columns if c != "SampleID"]
+        if len(cols) == 1:
+            our_col = cols[0]
+        else:
+            sys.exit(f"[{name}] column {our_col} not in {our.columns.tolist()}")
+    our = our[["SampleID", our_col]].rename(columns={our_col: "our_dosage"})
+    sih = sih[["SampleID", "scoreInvHap_dosage", "scoreInvHap_class"]]
+    m = our.merge(sih, on="SampleID", how="inner")
+    m = m.dropna(subset=["our_dosage", "scoreInvHap_dosage"])
+    m["name"] = name
+    m["model_col"] = our_col
+    return m
+
+
+def stats_for(name, m):
+    x = m["our_dosage"].to_numpy(dtype=float)
+    y = m["scoreInvHap_dosage"].to_numpy(dtype=float)
+    n = len(m)
+    if n < 3 or np.std(x) == 0 or np.std(y) == 0:
+        r = rho = np.nan
+    else:
+        r = pearsonr(x, y)[0]
+        rho = spearmanr(x, y)[0]
+    hard = float(np.mean(np.round(np.clip(x, 0, 2)).astype(int) ==
+                         np.round(y).astype(int)))
+    return {
+        "inversion": name,
+        "model_id": m["model_col"].iloc[0],
+        "n_samples": n,
+        "pearson_r": round(r, 4) if r == r else np.nan,
+        "r2": round(r * r, 4) if r == r else np.nan,
+        "spearman_rho": round(rho, 4) if rho == rho else np.nan,
+        "hardcall_concordance": round(hard, 4),
+        "our_inv_allele_freq": round(float(np.mean(x) / 2.0), 4),
+        "sih_inv_allele_freq": round(float(np.mean(y) / 2.0), 4),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-tsv", required=True)
+    ap.add_argument("--out-pdf", required=True)
+    ap.add_argument("--pair", nargs=4, action="append", metavar=
+                    ("NAME", "OUR_TSV", "OUR_COL", "SIH_TSV"), required=True)
+    args = ap.parse_args()
+
+    merged = [load_pair(*p) for p in args.pair]
+    rows = [stats_for(m["name"].iloc[0], m) for m in merged]
+    summary = pd.DataFrame(rows)
+    summary.to_csv(args.out_tsv, sep="\t", index=False)
+    print(summary.to_string(index=False))
+
+    npan = len(merged)
+    fig, axes = plt.subplots(1, npan, figsize=(5.2 * npan, 5), squeeze=False)
+    for ax, m, row in zip(axes[0], merged, rows):
+        jitter = (np.random.RandomState(0).rand(len(m)) - 0.5) * 0.12
+        ax.scatter(m["scoreInvHap_dosage"] + jitter, m["our_dosage"],
+                   s=8, alpha=0.35, edgecolors="none")
+        ax.plot([0, 2], [0, 2], color="red", lw=1, ls="--")
+        ax.set_xlim(-0.3, 2.3)
+        ax.set_ylim(-0.3, 2.3)
+        ax.set_xlabel("scoreInvHap genotype (jittered)")
+        ax.set_ylabel("Our imputed dosage")
+        r2 = row["r2"]
+        ax.set_title(f"{row['inversion']}\n"
+                     f"r2={r2}  n={row['n_samples']}  "
+                     f"hard={row['hardcall_concordance']}")
+    fig.tight_layout()
+    fig.savefig(args.out_pdf)
+    print(f"Wrote {args.out_tsv} and {args.out_pdf}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scoreinvhap_benchmark/infer_dosage_public.py
+++ b/scoreinvhap_benchmark/infer_dosage_public.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run our trained PLS imputation models on a public cohort (1000 Genomes).
+
+This is a thin, AoU-free wrapper around the inference logic in
+``imputation/infer_dosage.py``. The production inference fills missing
+genotypes using All-of-Us ancestry-specific means, which we deliberately do
+NOT use here (no AoU resources for public benchmarking). Instead we fill any
+missing genotype with the per-SNP global mean computed on the cohort itself,
+which is the standard mean-imputation fallback and is adequate because the
+1000 Genomes high-coverage panel is essentially complete at our tag SNPs.
+
+Inputs (produced by imputation/prepare_data_for_infer.py):
+  genotype_matrices/<model>.genotypes.npy   int8, shape (n_samples, n_snps)
+  subset.fam                                PLINK fam (sample order)
+  data/models/<model>.model.joblib          trained PLSRegression
+
+Output:
+  <out_tsv>  columns: SampleID, <model_id>  (imputed inverted-allele dosage)
+"""
+import os
+import sys
+import json
+
+import numpy as np
+import pandas as pd
+import joblib
+
+MISSING_VALUE_CODE = -127
+
+MODEL_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "models")
+GENOTYPE_DIR = os.getenv("GENOTYPE_DIR", "genotype_matrices")
+PLINK_PREFIX = os.getenv("PLINK_PREFIX", "subset")
+
+
+def global_mean_fill(X: np.ndarray) -> np.ndarray:
+    """Replace MISSING_VALUE_CODE with the per-column (per-SNP) mean."""
+    Xf = X.astype(np.float32, copy=True)
+    missing = Xf == MISSING_VALUE_CODE
+    if missing.any():
+        col_means = np.zeros(Xf.shape[1], dtype=np.float32)
+        for j in range(Xf.shape[1]):
+            valid = Xf[:, j][~missing[:, j]]
+            col_means[j] = valid.mean() if valid.size else 0.0
+        idx = np.where(missing)
+        Xf[idx] = col_means[idx[1]]
+    return Xf
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("Usage: infer_dosage_public.py <model_id> <out_tsv>")
+    model_id = sys.argv[1]
+    out_tsv = sys.argv[2]
+
+    fam = pd.read_csv(f"{PLINK_PREFIX}.fam", sep=r"\s+", header=None,
+                      usecols=[1], dtype=str)
+    sample_ids = fam[1].tolist()
+    n = len(sample_ids)
+    print(f"Samples: {n}")
+
+    mat_path = os.path.join(GENOTYPE_DIR, f"{model_id}.genotypes.npy")
+    X = np.load(mat_path, mmap_mode="r")
+    X = np.array(X, copy=True)
+    if X.shape[0] != n:
+        sys.exit(f"Sample mismatch: matrix {X.shape[0]} vs fam {n}")
+
+    miss_frac = float((X == MISSING_VALUE_CODE).mean())
+    print(f"Model {model_id}: matrix {X.shape}, global missingness {miss_frac:.4%}")
+
+    Xf = global_mean_fill(X)
+
+    clf = joblib.load(os.path.join(MODEL_DIR, f"{model_id}.model.joblib"))
+    pred = np.asarray(clf.predict(Xf)).reshape(-1).astype(np.float32)
+    # Dosage is biologically in [0, 2]; clip to that range for reporting.
+    pred = np.clip(pred, 0.0, 2.0)
+
+    out = pd.DataFrame({"SampleID": sample_ids, model_id: pred})
+    out.to_csv(out_tsv, sep="\t", index=False)
+    print(f"Wrote {len(out)} dosages to {out_tsv}")
+    print(out[model_id].describe())
+
+
+if __name__ == "__main__":
+    main()

--- a/scoreinvhap_benchmark/run_scoreinvhap.R
+++ b/scoreinvhap_benchmark/run_scoreinvhap.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+# Genotype the 8p23.1 and 17q21.31 inversions with the published tool
+# scoreInvHap (Ruiz-Arenas et al., PLOS Genetics 2019) on 1000 Genomes
+# phase-3 (GRCh37) samples.
+#
+# scoreInvHap ships reference objects built from 1000 Genomes for exactly the
+# two inversions the reviewer asked about: inv8_001 (8p23.1) and inv17_007
+# (17q21.31). Passing inv=<id> makes scoreInvHap() auto-load the matching
+# SNPsR2 / hetRefs / Refs reference objects internally.
+#
+# We emit, per sample, the maximum-posterior inversion genotype and its
+# numeric inverted-allele dosage (NN=0, NI=1, II=2).
+#
+# Usage:
+#   Rscript run_scoreinvhap.R <vcf> <inversion_key> <out_tsv>
+# where <inversion_key> is one of: inv8p23.1 inv17q21.31
+
+suppressMessages({
+  library(scoreInvHap)
+  library(VariantAnnotation)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 3) {
+  stop("Usage: run_scoreinvhap.R <vcf> <inversion_key> <out_tsv>")
+}
+vcf_path <- args[[1]]
+inv_key  <- args[[2]]
+out_tsv  <- args[[3]]
+
+# Map the human-facing key to the scoreInvHap reference identifier.
+key_map <- list(
+  "inv8p23.1"   = "inv8_001",
+  "inv17q21.31" = "inv17_007"
+)
+if (!inv_key %in% names(key_map)) {
+  stop(sprintf("Unknown inversion key '%s'", inv_key))
+}
+inv_id <- key_map[[inv_key]]
+
+cat(sprintf("Reading VCF %s for %s (scoreInvHap id %s)\n",
+            vcf_path, inv_key, inv_id))
+
+# Read genotypes. scoreInvHap reference SNPs are on GRCh37, matching the
+# 1000 Genomes phase-3 VCFs this workflow supplies.
+vcf <- readVcf(vcf_path, genome = "hg19")
+cat(sprintf("VCF variants read: %d ; samples: %d\n",
+            length(rowRanges(vcf)), ncol(vcf)))
+
+# inv=<id> triggers internal loading of the bundled reference objects.
+res <- scoreInvHap(SNPlist = vcf, inv = inv_id)
+
+# inversion=TRUE collapses haplotype labels (Na/Ia/...) into N/I, giving
+# inversion genotypes NN / NI / II.
+geno <- classification(res, inversion = TRUE)
+lab  <- as.character(geno)
+samples <- names(geno)
+
+dosage <- rep(NA_real_, length(lab))
+dosage[lab == "NN"] <- 0
+dosage[lab == "NI" | lab == "IN"] <- 1
+dosage[lab == "II"] <- 2
+# Generic fallback: count "I" characters in any unexpected 2-char label.
+unresolved <- which(is.na(dosage))
+for (i in unresolved) {
+  dosage[i] <- lengths(regmatches(lab[i], gregexpr("I", lab[i])))
+}
+
+best_score <- apply(scores(res), 1, max)
+# Align certainty/scores to the (possibly filtered) classification samples.
+best_score <- best_score[samples]
+
+out <- data.frame(
+  SampleID = samples,
+  scoreInvHap_class = lab,
+  scoreInvHap_dosage = dosage,
+  scoreInvHap_maxscore = round(as.numeric(best_score), 4),
+  stringsAsFactors = FALSE
+)
+write.table(out, out_tsv, sep = "\t", quote = FALSE, row.names = FALSE)
+cat(sprintf("Wrote %d genotypes to %s\n", nrow(out), out_tsv))
+cat("Class distribution:\n")
+print(table(out$scoreInvHap_class))


### PR DESCRIPTION
Addresses **Reviewer 2, comment 3**: benchmark our imputed inversion dosages against the published tool **scoreInvHap** (Ruiz-Arenas et al., PLOS Genetics 2019) for the **8p23.1** and **17q21.31** inversions in a large public sample (1000 Genomes), to demonstrate imputation reliability.

## Approach
Each method runs on its native genome build, then call sets are intersected on shared 1000 Genomes sample IDs:
- **scoreInvHap** genotypes `inv8_001` (8p23.1) and `inv17_007` (17q21.31) from the 1000G phase-3 (GRCh37) VCFs using its bundled reference objects.
- **Our PLS models** (`data/models/chr8-7301025-INV-5297356`, `chr17-45585160-INV-706887`) run on the 1000G high-coverage (GRCh38) VCFs. Missing genotypes are filled with the per-SNP cohort mean — no All-of-Us ancestry priors, public data only.

Inversion IDs verified against `data/inv_properties.tsv`.

## Deliverables
- `scoreinvhap_benchmark/` — R + Python scripts (scoreInvHap genotyping, our inference, concordance + scatter).
- `.github/workflows/scoreinvhap_concordance.yml` — installs R/Bioconductor + scoreInvHap, pulls ROI subsets of 1000G via tabix, runs both methods, writes `data/scoreinvhap_concordance.tsv` and `data/scoreinvhap_concordance.pdf` (per-inversion r²/Spearman/hard-call concordance).

Concordance numbers are produced by the CI run and committed to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)