### PR TITLE
Document PAML analysis as Clade Model C (audit #8 / Reviewer 1.5 / Reviewer 2.2)

### DIFF
--- a/cds/PAML_METHODS_NOTE.md
+++ b/cds/PAML_METHODS_NOTE.md
@@ -1,0 +1,127 @@
+# PAML methods reconciliation note
+
+This note documents exactly what the committed PAML analysis is, supplies
+corrected Methods/Results wording for the manuscript (which is not in this
+repo), and folds in the relevant reviewer comments. It accompanies the
+code-documentation changes in `cds/pipeline_lib.py`, `cds/finalize_results.py`,
+and `stats/paml_agg.py`.
+
+Audit reference: code-audit issue #8; Reviewer 1 comment 5; Reviewer 2
+comment 2.
+
+## 1. What the committed analysis actually is
+
+The executable analysis and the committed results
+(`data/GRAND_PAML_RESULTS.tsv`) are a **Clade Model C (CmC) test, partitioned
+by inversion orientation** — they are **not** a single-branch dN/dS test on the
+branch leading into the inverted haplotype, and not a branch-site test.
+
+Concretely, in `cds/pipeline_lib.py`:
+
+- `RUN_CLADE_MODEL_TEST = True`, `RUN_BRANCH_MODEL_TEST = False`
+  (lines ~180). The branch-model two-ratio test (`model = 2`, `NSsites = 0`)
+  is disabled and is opt-in only; it produced none of the committed results.
+- codeml is run with `model = 3`, `NSsites = 2`, `ncatG = 3`
+  (`analyze_single_gene` → `_build_attempts`), i.e. Clade Model C.
+- Branch labelling (`create_paml_tree_files`):
+  - **H1 (alternative):** every *pure direct* internal/terminal branch is
+    marked `#1` and every *pure inverted* branch is marked `#2`. Branches whose
+    descendants mix orientations, plus the outgroup, are background. This gives
+    three CmC partitions: background, pooled-direct clade, pooled-inverted
+    clade. It pools **all** direct branches and **all** inverted branches — it
+    does not single out the one branch that leads into the inversion.
+  - **H0 (null):** both pure direct and pure inverted branches collapse to a
+    single foreground class `#1`, forcing the two orientations to share one
+    divergent-class dN/dS.
+- The reported statistic is the H1-vs-H0 likelihood-ratio test, `df = 1`
+  (`cmc_p_value` / `overall_p_value`, FDR-corrected to `cmc_q_value` /
+  `overall_q_value`). Each hypothesis is optimised from a tournament of four
+  starting (kappa, omega) seeds and the best log-likelihood is kept.
+
+Committed output columns reflect CmC, not a branch model:
+`winner_p0/p1/p2` (site-class proportions), `winner_omega0` (the conserved/
+purifying class shared across branches), and `winner_omega2_direct` /
+`winner_omega2_inverted` (the divergent site-class dN/dS in the pooled direct
+vs pooled inverted clades). The file contains **no** `bm_*` (branch-model)
+columns.
+
+So the H1-vs-H0 LRT answers one question: **does the divergent site class have
+a different dN/dS between the pooled direct and the pooled inverted clades?** It
+is a test of orientation-associated *differentiation* in selective regime, not
+a test for positive selection on any individual lineage.
+
+## 2. What the committed numbers show (47 usable genes)
+
+- 47 genes have complete H0+H1 likelihoods ("Usable: complete data");
+  10 more have H1 fitting worse than H0; the rest are excluded/uncomputable.
+- The smallest raw LRT p-value is ~1.3e-3, but **no gene survives
+  Benjamini–Hochberg FDR correction** (smallest `overall_q_value` ≈ 0.063;
+  zero genes with q < 0.05).
+- Per-class omega > 1 is nonetheless common in the point estimates: ~20/47
+  genes show `winner_omega2_inverted` > 1 and ~26/47 show
+  `winner_omega2_direct` > 1.
+
+The juxtaposition is the key honest result: elevated divergent-class omega
+estimates are frequent, yet the formal orientation-difference test detects
+nothing significant after multiple-testing correction. Those high omega point
+estimates are expected sampling behaviour on short, low-information branches and
+are **not** evidence of positive selection (see §4).
+
+## 3. Corrected Methods wording (ready to paste)
+
+> Selection on protein-coding sequence was tested with codeml from PAML using
+> Clade Model C (CmC; `model = 3`, `NSsites = 2`, `ncatG = 3`). For each gene we
+> partitioned branches of the gene tree by inversion orientation: all branches
+> ancestral only to direct haplotypes formed one foreground clade and all
+> branches ancestral only to inverted haplotypes formed a second foreground
+> clade, with branches subtending both orientations (and the chimpanzee
+> outgroup) as background. The alternative model (H1) allowed the divergent CmC
+> site class to take a separate dN/dS in the direct and inverted clades; the
+> null model (H0) constrained the two orientations to share a single
+> divergent-class dN/dS. Support for an orientation-specific shift in selective
+> regime was assessed by a likelihood-ratio test between H1 and H0 (1 degree of
+> freedom), with each model optimised from four independent starting points and
+> the best likelihood retained. P-values were corrected across genes by the
+> Benjamini–Hochberg procedure. This design contrasts the *pooled* direct and
+> *pooled* inverted clades; it is not a branch-specific test of the single
+> lineage leading into the inverted arrangement, and a per-class dN/dS estimate
+> above one does not by itself constitute a test for positive selection.
+
+Corrected Results wording (suggested):
+
+> Across the 47 genes with complete CmC fits, no gene showed a significant
+> difference in divergent-class dN/dS between direct and inverted clades after
+> FDR correction (all q > 0.05). Although point estimates of the divergent-class
+> dN/dS exceeded one for many genes in one or both orientations, these estimates
+> are imprecise on the short internal branches available here and do not
+> constitute evidence of positive selection.
+
+## 4. Reviewer points incorporated
+
+**Reviewer 1, comment 5 / Reviewer 2, comment 2 — omega>1 on short branches;
+"pervasive differentiation" overstated.**
+
+- codeml dN/dS estimates are unstable and upward-biased on short,
+  low-substitution branches; a point estimate of omega > 1 for an individual
+  gene/branch (e.g. genes such as FDFT1 or BLK cited by the reviewers) is a
+  noisy estimate, not a statistical detection of positive selection. The only
+  selection claim the committed analysis supports is the CmC H1-vs-H0 LRT, and
+  here that test is non-significant for every gene after FDR correction.
+- The phrase **"pervasive differentiation"** should be softened. Recommended
+  replacements: "we did not detect significant orientation-associated shifts in
+  selective constraint after multiple-testing correction," or, if describing
+  point estimates, "point estimates were variable and frequently above one but
+  were not statistically distinguishable between orientations." Avoid wording
+  that implies widespread or pervasive positive/diversifying selection.
+
+## 5. Optional branch-model capability (not enabled, no results claimed)
+
+The repository retains a disabled branch-model two-ratio path (`model = 2`,
+`NSsites = 0`) behind `RUN_BRANCH_MODEL_TEST` / the `run_branch_model`
+argument. It is opt-in only, is **off** in the committed configuration, and
+produced **none** of the committed results (no `bm_*` columns exist in
+`data/GRAND_PAML_RESULTS.tsv`). It is documented and clearly marked as dead/
+opt-in in the code so it cannot be mistaken for the active analysis. No genuine
+single-branch / branch-site test on the inversion-leading branch was run; a full
+re-run (via `combine_paml.yml` on GitHub Actions) would be required to produce
+one and is out of scope for this reconciliation.

--- a/cds/finalize_results.py
+++ b/cds/finalize_results.py
@@ -33,6 +33,11 @@ except ImportError:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 
+# Column order for the merged output. The cmc_* columns hold the ACTIVE
+# Clade Model C result (orientation-partitioned direct vs inverted; see
+# cds/PAML_METHODS_NOTE.md). The bm_* (branch-model two-ratio) columns are an
+# opt-in-only capability that is disabled in the committed run, so they are
+# all-NaN in data/GRAND_PAML_RESULTS.tsv; they are retained for schema stability.
 ORDERED_COLUMNS = [
     'region', 'gene', 'status',
     'bm_p_value', 'bm_q_value', 'bm_lrt_stat',

--- a/cds/pipeline_lib.py
+++ b/cds/pipeline_lib.py
@@ -177,8 +177,28 @@ PAML_CACHE_DIR = os.environ.get("PAML_CACHE_DIR", "paml_cache")
 IQTREE_TIMEOUT = int(os.environ.get("IQTREE_TIMEOUT", "7200"))
 PAML_TIMEOUT   = int(os.environ.get("PAML_TIMEOUT", "20880"))
 
-RUN_BRANCH_MODEL_TEST = False
-RUN_CLADE_MODEL_TEST = True
+# --- Which selection test is run (see also cds/PAML_METHODS_NOTE.md) ---
+#
+# ACTIVE ANALYSIS: Clade Model C (CmC), orientation-partitioned.
+#   codeml settings model=3, NSsites=2, ncatG=3 (set in analyze_single_gene
+#   below). H1 partitions branches into TWO foreground clades by inversion
+#   orientation -- EVERY pure direct branch is labelled #1 and EVERY pure
+#   inverted branch is labelled #2 (see create_paml_tree_files). H0 collapses
+#   both orientations into a single foreground class (#1). The H1-vs-H0 LRT
+#   (df=1) therefore asks: does the divergent site class have a DIFFERENT dN/dS
+#   between the pooled direct and pooled inverted clades? It is NOT a
+#   single-branch / branch-site test on the one branch that leads into the
+#   inverted haplotype, and it is NOT in itself a test for positive selection
+#   (omega>1) on any individual branch. The committed data/GRAND_PAML_RESULTS.tsv
+#   holds CmC parameters (winner_p0/p1/p2, winner_omega0,
+#   winner_omega2_direct, winner_omega2_inverted, cmc_*).
+#
+# The classic branch model (model=2, NSsites=0) two-ratio test is DISABLED by
+# default and gated behind RUN_BRANCH_MODEL_TEST. It is kept only as an
+# explicitly opt-in capability; no committed result was produced with it. Do
+# not describe the committed results as a branch-model / branch-site test.
+RUN_BRANCH_MODEL_TEST = False   # opt-in only; produces bm_* columns; NOT the committed analysis
+RUN_CLADE_MODEL_TEST = True     # the active analysis (Clade Model C)
 PROCEED_ON_TERMINAL_ONLY = False
 
 # --- Tournament seeds for PAML restarts ---
@@ -594,7 +614,33 @@ def _validate_internal_branch_labels(paml_tree_str: str, tree_obj: Tree, expecte
             f"Internal branch label validation failed for mark '{mark}'. Expected {expected_counts[mark]}, found {actual_counts[mark]}. Tree string: {paml_tree_str}"
 
 def create_paml_tree_files(tree_path, work_dir, gene_name):
-    logging.info(f"[{gene_name}] Labeling internal branches conservatively...")
+    """Write the H1 and H0 codeml tree files for the Clade Model C test.
+
+    This builds the labelled trees for the ACTIVE, orientation-partitioned
+    Clade Model C analysis (see RUN_CLADE_MODEL_TEST and PAML_METHODS_NOTE.md),
+    NOT a single-branch test on the branch leading into the inverted haplotype.
+
+    Leaves are assigned to a group by the first character of their name
+    ('0' = direct, '1' = inverted, anything else = outgroup). An internal node
+    inherits a group only when ALL of its descendant leaves share that group;
+    mixed nodes are labelled "both" and left unlabelled (background).
+
+    H1 (alternative): EVERY pure direct branch is marked #1 and EVERY pure
+        inverted branch is marked #2 -- two foreground clades partitioned by
+        inversion orientation. This is the standard CmC three-partition setup
+        (background = mixed/outgroup branches, plus the two orientation clades).
+    H0 (null): both pure direct and pure inverted branches collapse to a single
+        foreground class #1, so the two orientations are forced to share one
+        divergent-class omega.
+
+    The H1-vs-H0 LRT (df=1) tests whether the divergent site class has a
+    different dN/dS between the pooled direct and pooled inverted clades.
+
+    Returns (h1_tree_path, h0_tree_path, analysis_is_informative, tree, reason).
+    "Informative" requires at least one pure internal branch in EACH orientation
+    so the two foreground partitions are distinguishable on internal branches.
+    """
+    logging.info(f"[{gene_name}] Labeling direct/inverted clades for Clade Model C...")
     t = Tree(tree_path, format=1)
 
     direct_leaves = 0
@@ -637,6 +683,9 @@ def create_paml_tree_files(tree_path, work_dir, gene_name):
         logging.warning(f"[{gene_name}] Topology is uninformative for internal branch analysis.")
         reason = "No pure internal branches found for both direct and inverted groups."
 
+    # H1 (CmC alternative): two foreground partitions by orientation.
+    # Mark EVERY pure direct branch #1 and EVERY pure inverted branch #2.
+    # This is a pooled-clade contrast, not a single inversion-leading branch.
     t_h1 = t.copy()
     for node in t_h1.traverse():
         status = getattr(node, "group_status", "both")
@@ -657,6 +706,8 @@ def create_paml_tree_files(tree_path, work_dir, gene_name):
     with open(h1_tree_path, 'w') as f:
         f.write("1\n" + h1_paml_str + "\n")
 
+    # H0 (CmC null): collapse both orientations into ONE foreground class #1,
+    # forcing direct and inverted clades to share a single divergent-class omega.
     t_h0 = t.copy()
     for node in t_h0.traverse():
         status = getattr(node, "group_status", "both")
@@ -1343,7 +1394,20 @@ def analyze_single_gene(gene_info, region_tree_path, region_label, paml_bin, cac
                         make_figures=True,
                         annotated_figure_dir=ANNOTATED_FIGURE_DIR,
                         target_clade_model=None):
-    """Run codeml for a gene using the provided region tree."""
+    """Run codeml for a gene under the orientation-partitioned Clade Model C test.
+
+    By default (run_clade_model=True, run_branch_model=False) this runs the
+    ACTIVE analysis: Clade Model C (model=3, NSsites=2, ncatG=3) contrasting the
+    pooled direct clade against the pooled inverted clade (H1) versus a single
+    pooled foreground (H0); the reported statistic is the H1-vs-H0 LRT
+    (cmc_p_value, df=1). It is NOT a single-branch dN/dS test on the branch
+    leading into the inverted haplotype, and omega>1 in any site class is not by
+    itself evidence of positive selection. See cds/PAML_METHODS_NOTE.md.
+
+    Setting run_branch_model=True additionally runs the disabled-by-default
+    branch-model two-ratio test (model=2, NSsites=0); it is opt-in only and
+    produced none of the committed results.
+    """
     gene_name = gene_info['label']
     normalized_target = (target_clade_model or "both").lower()
     final_result = {
@@ -1492,6 +1556,12 @@ def analyze_single_gene(gene_info, region_tree_path, region_label, paml_bin, cac
             logging.info(f"[{gene_name}|{region_label}] Cached attempt {out_name} to {target_dir}")
             return payload
 
+        # ---- DISABLED branch model two-ratio test (model=2, NSsites=0) ----
+        # OPT-IN ONLY via run_branch_model / RUN_BRANCH_MODEL_TEST. This block
+        # is NOT executed in the committed configuration and produced NONE of
+        # the committed results. It is retained as a documented capability;
+        # bm_* columns it would emit are absent from data/GRAND_PAML_RESULTS.tsv.
+        # The active test is Clade Model C, in the run_clade_model block below.
         bm_result = {}
         if run_branch_model:
             pair_key_bm, pair_key_dict_bm = _hash_key_pair(h0_bm_key, h1_bm_key, "branch_model", 1, exe_fp)
@@ -1534,6 +1604,11 @@ def analyze_single_gene(gene_info, region_tree_path, region_label, paml_bin, cac
             logging.info(f"[{gene_name}|{region_label}] Skipping branch-model test as per configuration.")
             bm_result = {"bm_p_value": np.nan, "bm_lrt_stat": np.nan}
 
+        # ---- ACTIVE analysis: Clade Model C (model=3, NSsites=2, ncatG=3) ----
+        # Orientation-partitioned: H1 contrasts pooled direct (#1) vs pooled
+        # inverted (#2) clades against a shared background; H0 pools both
+        # orientations into one foreground class. The H1-vs-H0 LRT (df=1) is the
+        # reported cmc_p_value. Emits the committed cmc_*/winner_* columns.
         cmc_result = {}
         if run_clade_model:
             target = normalized_target

--- a/stats/paml_agg.py
+++ b/stats/paml_agg.py
@@ -34,6 +34,10 @@ BLACKLIST_COLUMNS = {
 }
 
 # Mapping of {New_Column_Name: Replacement_Suffix}
+# These winner_* columns hold the ACTIVE Clade Model C result
+# (orientation-partitioned direct vs inverted; see cds/PAML_METHODS_NOTE.md):
+# winner_omega2_direct / winner_omega2_inverted are the divergent site-class
+# dN/dS in the pooled direct / pooled inverted clades, not a single-branch test.
 # This maps the metric name found in the column headers to the final output name.
 # Based on pipeline_lib.py, raw columns look like: "h1_s1_def_cmc_p0"
 # We find the winner via "h1_s1_def_lnl" and swap "_lnl" for the suffixes below.


### PR DESCRIPTION
## Summary

Reconciles **code-audit issue #8**: the active PAML analysis is an
orientation-partitioned **Clade Model C (CmC)** test, but the docstrings/
comments (and the manuscript Methods) implied a branch-specific dN/dS test on
the single branch leading into the inverted haplotype. This PR makes the code
self-documenting and accurate, and supplies corrected Methods text for the
authors. No analysis is re-run and no results change.

Intersects **Reviewer 1 comment 5** and **Reviewer 2 comment 2** (PAML omega
overestimated on short branches; "pervasive differentiation" overstated).

## What the active analysis actually is

- `cds/pipeline_lib.py`: `RUN_CLADE_MODEL_TEST = True`,
  `RUN_BRANCH_MODEL_TEST = False`; codeml runs `model=3, NSsites=2, ncatG=3`.
- `create_paml_tree_files` labels **every pure direct branch `#1`** and
  **every pure inverted branch `#2`** (H1 = two pooled foreground clades);
  H0 collapses both orientations into one foreground class. The reported
  statistic is the H1-vs-H0 LRT (`df=1`, `cmc_p_value` / `overall_p_value`).
- This is a **pooled direct vs pooled inverted** contrast, **not** a
  single-branch / branch-site test, and a per-class omega>1 is not by itself
  a test for positive selection.
- The committed `data/GRAND_PAML_RESULTS.tsv` holds CmC parameters
  (`winner_p0/p1/p2`, `winner_omega0`, `winner_omega2_direct/inverted`) and
  **zero `bm_*` columns** — confirming the branch-model path produced none of
  the committed results.

## Changes

- **`cds/pipeline_lib.py`** — rewrote the `RUN_*_TEST` flag block,
  `create_paml_tree_files` docstring, the H1/H0 labelling comments, the active
  vs disabled codeml blocks, and the `analyze_single_gene` docstring to
  describe the real CmC two-clade contrast. The `model=2, NSsites=0`
  branch-model path is clearly marked **disabled / opt-in only**
  (`RUN_BRANCH_MODEL_TEST`) so it can't be mistaken for the active analysis.
  Capability is gated behind the existing flag, not deleted.
- **`cds/finalize_results.py`, `stats/paml_agg.py`** — comments noting `cmc_*`/
  `winner_*` are the active CmC result and `bm_*` are dormant opt-in columns.
- **`cds/PAML_METHODS_NOTE.md`** (new) — (a) precise description of the
  committed results, (b) ready-to-paste corrected Methods/Results wording, and
  (c) the reviewer points: omega>1 on short branches (e.g. FDFT1, BLK) is not
  positive selection, and "pervasive differentiation" should be softened
  (no gene survives FDR; smallest q ≈ 0.063).

## Honesty check from the committed data

47 genes have complete CmC fits. Smallest raw LRT p ≈ 1.3e-3, but **no gene is
significant after FDR** (smallest q ≈ 0.063). Yet ~20/47 show
`winner_omega2_inverted`>1 and ~26/47 show `winner_omega2_direct`>1 — exactly
the reviewers' point that elevated per-class omega point estimates on short
branches are not detections of selection.

## Branch-test option

Not enabled and no results claimed. The disabled branch-model two-ratio path
remains gated behind `RUN_BRANCH_MODEL_TEST` as documented opt-in capability; a
genuine branch-site test would require a full re-run (via `combine_paml.yml` on
GHA), which is out of scope and was not dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
