### PR TITLE
Consolidate codon-aware diversity into one shared module + tests

### DIFF
--- a/stats/_codon_diversity.py
+++ b/stats/_codon_diversity.py
@@ -1,0 +1,233 @@
+"""Single source of truth for codon-aware coding-sequence diversity.
+
+Both ``stats/four_fold_pi.py`` (4-fold synonymous π) and ``stats/pin_pis.py``
+(πN at 0-fold / πS at 4-fold sites) previously duplicated the PHYLIP reader, the
+per-site π estimator, the standard genetic code, the degeneracy classification and
+the per-site π loop. The duplication let the two drift apart: four_fold_pi gained a
+codon-aware π fix (a haplotype only contributes its third base at a 4-fold site when
+its OWN first two codon positions establish a 4-fold family) while pin_pis kept a
+plain per-column π that counted bases from haplotypes whose codon family was unknown
+(N/gap at codon positions 1-2). This module centralises the shared logic so the two
+analyses cannot diverge again, and exposes one codon-aware π routine used by both.
+
+Conventions:
+- Sequences are equal-length uppercase strings over A/C/G/T/N/-, in reading frame
+  (codon i spans columns 3i, 3i+1, 3i+2).
+- A "site" for codon-aware π is a triple (codon_start, pos, cls) where pos in {0,1,2}
+  and cls in {"0","4"} (0-fold / 4-fold). The measured column is codon_start+pos.
+"""
+from __future__ import annotations
+
+import gzip
+import itertools
+import re
+from collections import Counter
+
+import numpy as np
+
+VALID = frozenset("ACGT")
+
+# ------------------------- genetic code / degeneracy -------------------------
+# Standard genetic code (NCBI translation table 1).
+_BASES = "TCAG"
+_AA = (
+    "FFLLSSSSYY**CC*W"
+    "LLLLPPPPHHQQRRRR"
+    "IIIMTTTTNNKKSSRR"
+    "VVVVAAAADDEEGGGG"
+)
+CODON_TABLE = {
+    a + b + c: _AA[i]
+    for i, (a, b, c) in enumerate(itertools.product(_BASES, repeat=3))
+}
+
+
+def degeneracy(codon, pos):
+    """N-fold degeneracy of ``pos`` (0,1,2) in ``codon`` under the standard code.
+
+    Counts how many of the four nucleotides at ``pos`` yield the same amino acid as
+    ``codon`` (the codon itself counts). Returns ``None`` for a stop / undefined
+    codon, so such codons belong to neither the 0-fold nor the 4-fold set."""
+    aa = CODON_TABLE.get(codon)
+    if aa is None or aa == "*":
+        return None
+    n_same = 0
+    for b in _BASES:
+        if CODON_TABLE.get(codon[:pos] + b + codon[pos + 1:]) == aa:
+            n_same += 1
+    return n_same
+
+
+# Precomputed (codon, pos) -> bool for sense codons.
+ZEROFOLD = {}
+FOURFOLD = {}
+for _cod in CODON_TABLE:
+    if CODON_TABLE[_cod] == "*":
+        continue
+    for _p in range(3):
+        _d = degeneracy(_cod, _p)
+        ZEROFOLD[(_cod, _p)] = (_d == 1)
+        FOURFOLD[(_cod, _p)] = (_d == 4)
+
+# The eight 4-fold-degenerate codon prefixes (positions 1-2). A codon's third
+# position is 4-fold iff its first two bases form one of these families; this is
+# exactly {prefix : FOURFOLD[(prefix+X, 2)] for any X}.
+FOURFOLD_PREFIXES = frozenset(
+    cod[:2] for cod in CODON_TABLE if FOURFOLD.get((cod, 2))
+)
+
+# Codon sets by position/class for O(1) membership in the hot per-site pi loop.
+_ZERO_CODONS_BY_POS = (set(), set(), set())
+_FOUR_CODONS_BY_POS = (set(), set(), set())
+for (_c, _p), _v in ZEROFOLD.items():
+    if _v:
+        _ZERO_CODONS_BY_POS[_p].add(_c)
+for (_c, _p), _v in FOURFOLD.items():
+    if _v:
+        _FOUR_CODONS_BY_POS[_p].add(_c)
+
+
+# ------------------------------ PHYLIP I/O ------------------------------
+def read_phy(path):
+    """Return ``(sequences, length)`` from a (optionally gzipped) PHYLIP alignment.
+
+    Mirrors the sequence extraction in cds/axt_to_phy.py. Returns ``([], length)``
+    if the file is malformed or rows are ragged."""
+    opener = gzip.open if str(path).endswith(".gz") else open
+    seqs = []
+    with opener(path, "rt") as fh:
+        first = fh.readline().split()
+        if len(first) != 2:
+            return [], 0
+        try:
+            exp_len = int(first[1])
+        except ValueError:
+            return [], 0
+        for line in fh:
+            if not line.strip():
+                continue
+            m = re.search(r"([ACGTNacgtn-]+)\s*$", line)
+            if m:
+                seqs.append(m.group(1).upper())
+    if not seqs:
+        return [], exp_len
+    L = len(seqs[0])
+    if any(len(s) != L for s in seqs) or L != exp_len:
+        return [], exp_len
+    return seqs, L
+
+
+# ------------------------------ π estimator ------------------------------
+def site_pi(column):
+    """Per-site π with the Rust pipeline estimator (src/stats.rs).
+
+    ``column`` is an iterable of single-character bases. Returns ``None`` for an
+    uncallable site (< 2 called A/C/G/T bases)."""
+    counts = Counter(b for b in column if b in VALID)
+    n = sum(counts.values())
+    if n < 2:
+        return None
+    sum_sq = sum(c * c for c in counts.values())
+    return n / (n - 1.0) * (1.0 - sum_sq / (n * n))
+
+
+def locus_pi(seqs, columns):
+    """Mean per-site π over ``columns`` (callable sites only). For whole-CDS /
+    whole-locus π where every called base at a column is counted."""
+    vals = []
+    for col in columns:
+        p = site_pi(s[col] for s in seqs)
+        if p is not None:
+            vals.append(p)
+    if not vals:
+        return np.nan, 0
+    return float(np.mean(vals)), len(vals)
+
+
+# ----------------------- codon-site classification -----------------------
+def fourfold_codon_starts(seqs, L):
+    """Yield the start index of each codon that is 4-fold-degenerate at position 3.
+
+    A codon is included only when every *called* haplotype (ACGT at positions 1-2)
+    carries a 4-fold prefix; haplotypes with a gap/N at positions 1-2 are ignored
+    here (family unknown) and are also excluded from this codon's π by
+    :func:`class_aware_locus_pi`."""
+    for cs in range(0, L - 2, 3):
+        ok = False
+        for s in seqs:
+            p1, p2 = s[cs], s[cs + 1]
+            if p1 in VALID and p2 in VALID:
+                if (p1 + p2) not in FOURFOLD_PREFIXES:
+                    ok = False
+                    break
+                ok = True
+        if ok:
+            yield cs
+
+
+def classify_zero_four(seqs, L):
+    """Classify each codon position as 0-fold / 4-fold across the sample.
+
+    Yields ``(column_index, "0" | "4")``. A position is reported only when every
+    fully-called (ACGT) codon agrees on the class; codons with gap/N/stop in a
+    haplotype don't vote, and a disagreement skips the position. Classification is
+    done once on the combined sample so it is orientation-independent."""
+    for cs in range(0, L - 2, 3):
+        for pos in range(3):
+            col = cs + pos
+            is_zero = is_four = True
+            seen = False
+            for s in seqs:
+                codon = s[cs:cs + 3]
+                if any(b not in VALID for b in codon):
+                    continue
+                key = (codon, pos)
+                if key not in ZEROFOLD:  # stop codon
+                    is_zero = is_four = False
+                    break
+                seen = True
+                if not ZEROFOLD[key]:
+                    is_zero = False
+                if not FOURFOLD[key]:
+                    is_four = False
+                if not is_zero and not is_four:
+                    break
+            if not seen:
+                continue
+            if is_zero:
+                yield col, "0"
+            elif is_four:
+                yield col, "4"
+
+
+def class_aware_locus_pi(seqs, sites):
+    """Mean per-site π at degenerate sites, counting each haplotype's base ONLY when
+    its own codon establishes the required degeneracy class.
+
+    ``sites`` is an iterable of ``(codon_start, pos, cls)`` with ``cls`` in
+    ``{"0","4"}``. For each site the measured column is ``codon_start + pos``; a
+    haplotype contributes its base there only if its full codon (the three columns
+    from ``codon_start``) is ACGT and is ``cls``-fold at ``pos``. This is the
+    codon-aware rule from four_fold_pi, generalised to 0-fold sites for pin_pis, so
+    a haplotype with N/gap elsewhere in the codon (unknown family) never contributes.
+
+    Returns ``(mean_pi, n_callable_sites)``."""
+    # Group sites by codon_start so each haplotype's codon is sliced once per codon
+    # (not once per position), and use precomputed codon-class sets for membership.
+    by_codon = {}
+    for cs, pos, cls in sites:
+        by_codon.setdefault(cs, []).append((pos, cls))
+
+    vals = []
+    for cs, posclasses in by_codon.items():
+        codons = [s[cs:cs + 3] for s in seqs]
+        for pos, cls in posclasses:
+            want = _FOUR_CODONS_BY_POS[pos] if cls == "4" else _ZERO_CODONS_BY_POS[pos]
+            col = cs + pos
+            bases = [s[col] for s, codon in zip(seqs, codons) if codon in want]
+            p = site_pi(bases)
+            if p is not None:
+                vals.append(p)
+    if not vals:
+        return np.nan, 0
+    return float(np.mean(vals)), len(vals)

--- a/stats/four_fold_pi.py
+++ b/stats/four_fold_pi.py
@@ -57,6 +57,11 @@ import matplotlib.pyplot as plt
 import sys as _sys
 _sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _inv_common import is_flipped  # chimp polarization: group0/1 -> ancestral/derived
+# Single source of truth for codon-aware diversity (shared with pin_pis.py).
+from _codon_diversity import (
+    VALID, FOURFOLD_PREFIXES, read_phy, site_pi, locus_pi,
+    fourfold_codon_starts as fourfold_columns, class_aware_locus_pi,
+)
 
 warnings.filterwarnings("ignore")
 
@@ -88,12 +93,8 @@ OUT_TABLE = os.path.join(_DATA_DIR, "four_fold_pi_by_inversion.tsv")
 OUT_TESTS = os.path.join(_DATA_DIR, "four_fold_pi_tests.tsv")
 OUT_FIG = os.path.join(_DATA_DIR, "four_fold_pi.pdf")
 
-VALID = set("ACGT")
-
-# Eight fourfold-degenerate codon families: the first two positions fully
-# determine the amino acid regardless of the third position. The third position
-# is therefore a fourfold-degenerate (synonymous) site.
-FOURFOLD_PREFIXES = {"CT", "GT", "TC", "CC", "AC", "GC", "CG", "GG"}
+# VALID and FOURFOLD_PREFIXES are imported from _codon_diversity (single source of
+# truth) so four_fold_pi and pin_pis cannot drift apart.
 
 # ------------------------- PHYLIP I/O ------------------------
 
@@ -161,113 +162,20 @@ def resolve_phy_dir():
     return tmp, tmp
 
 
-def read_phy(path):
-    """Return list of (uppercased) sequences from a PHYLIP .phy.gz alignment.
-
-    Mirrors the sequence extraction in cds/axt_to_phy.py: a header line of two
-    integers, then one sequence per line with the sequence as the final
-    whitespace-delimited token (names may contain '_L'/'_R')."""
-    seqs = []
-    with gzip.open(path, "rt") as fh:
-        first = fh.readline().split()
-        if len(first) != 2:
-            return [], 0
-        try:
-            exp_len = int(first[1])
-        except ValueError:
-            return [], 0
-        for line in fh:
-            if not line.strip():
-                continue
-            m = re.search(r"([ACGTNacgtn-]+)\s*$", line)
-            if m:
-                seqs.append(m.group(1).upper())
-    if not seqs:
-        return [], exp_len
-    L = len(seqs[0])
-    if any(len(s) != L for s in seqs) or L != exp_len:
-        return [], exp_len
-    return seqs, L
-
-
-# ------------------------- PI ESTIMATOR ----------------------
-
-
-def site_pi(column):
-    """Per-site pi with the Rust pipeline estimator (src/stats.rs).
-
-    column: iterable of single-character bases for one alignment column.
-    Returns None for uncallable sites (< 2 called A/C/G/T haplotypes)."""
-    counts = Counter(b for b in column if b in VALID)
-    n = sum(counts.values())
-    if n < 2:
-        return None
-    sum_sq = sum(c * c for c in counts.values())
-    return n / (n - 1.0) * (1.0 - sum_sq / (n * n))
-
-
-def fourfold_columns(seqs, L):
-    """Yield the codon-start index of each fourfold-degenerate codon.
-
-    A codon is included only when every *called* haplotype (ACGT at positions 1-2) carries a
-    fourfold-family prefix; if any called haplotype has a non-fourfold prefix the codon is
-    skipped. Haplotypes with a gap/N at positions 1-2 are ignored *here* (their family is
-    unknown) -- and, crucially, they are also excluded from this codon's pi by
-    ``fourfold_locus_pi``, which re-checks each haplotype's own prefix before counting its
-    third base. Yields the codon start (the third position is ``codon_start + 2``)."""
-    for codon_start in range(0, L - 2, 3):
-        ok = True
-        seen_called = False
-        for s in seqs:
-            p1, p2 = s[codon_start], s[codon_start + 1]
-            if p1 in VALID and p2 in VALID:
-                seen_called = True
-                if (p1 + p2) not in FOURFOLD_PREFIXES:
-                    ok = False
-                    break
-        if ok and seen_called:
-            yield codon_start
-
-
-def locus_pi(seqs, columns):
-    """Mean per-site pi over the given columns (callable sites only)."""
-    vals = []
-    for col in columns:
-        p = site_pi(s[col] for s in seqs)
-        if p is not None:
-            vals.append(p)
-    if not vals:
-        return np.nan, 0
-    return float(np.mean(vals)), len(vals)
+# read_phy, site_pi, locus_pi, fourfold_columns (= fourfold_codon_starts) are
+# imported from _codon_diversity. fourfold_locus_pi is the codon-aware 4-fold third-
+# position estimator, expressed via the shared class_aware_locus_pi so pin_pis uses
+# the identical rule (a haplotype contributes its third base only when its own first
+# two codon positions establish a 4-fold family; N/gap there excludes it).
 
 
 def fourfold_locus_pi(seqs, codon_starts):
-    """Mean per-site pi at fourfold third positions.
-
-    Each haplotype contributes its third base at a codon ONLY when its own first two bases
-    establish a fourfold-degenerate family. Haplotypes with a gap/N (or any non-fourfold
-    prefix) at positions 1-2 are excluded from that codon's pi, because their third base
-    cannot be assumed synonymous. This fixes the prior behaviour where such a haplotype was
-    ignored when classifying the column as fourfold yet still counted in pi (e.g.
-    ['GCA','NNG'] wrongly yielded pi = 1.0 at the third position)."""
-    vals = []
-    for cs in codon_starts:
-        col = cs + 2
-        bases = [
-            s[col] for s in seqs
-            if s[cs] in VALID and s[cs + 1] in VALID and (s[cs] + s[cs + 1]) in FOURFOLD_PREFIXES
-        ]
-        p = site_pi(bases)
-        if p is not None:
-            vals.append(p)
-    if not vals:
-        return np.nan, 0
-    return float(np.mean(vals)), len(vals)
+    """Mean per-site pi at fourfold third positions (codon-aware; see module note)."""
+    return class_aware_locus_pi(seqs, [(cs, 2, "4") for cs in codon_starts])
 
 
 def whole_cds_pi(seqs, L):
-    cols = range(L)
-    return locus_pi(seqs, cols)
+    return locus_pi(seqs, range(L))
 
 
 # ------------------------- DATA LOADING ----------------------

--- a/stats/pin_pis.py
+++ b/stats/pin_pis.py
@@ -68,6 +68,13 @@ import matplotlib.pyplot as plt
 import sys as _sys
 _sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _inv_common import is_flipped  # chimp polarization: group0/1 -> ancestral/derived
+# Single source of truth for codon-aware diversity (shared with four_fold_pi.py):
+# the genetic code, degeneracy classification, PHYLIP reader, per-site pi estimator,
+# and the codon-aware per-site pi that excludes haplotypes of unknown codon family.
+from _codon_diversity import (
+    VALID, read_phy, site_pi, locus_pi,
+    classify_zero_four as degenerate_columns, class_aware_locus_pi,
+)
 
 warnings.filterwarnings("ignore")
 
@@ -96,52 +103,9 @@ OUT_TABLE = os.path.join(_DATA_DIR, "pin_pis_by_inversion.tsv")
 OUT_TESTS = os.path.join(_DATA_DIR, "pin_pis_tests.tsv")
 OUT_FIG = os.path.join(_DATA_DIR, "pin_pis.pdf")
 
-VALID = set("ACGT")
-
-# ------------------------- GENETIC CODE / DEGENERACY ----------
-
-# Standard genetic code (NCBI translation table 1).
-BASES = "TCAG"
-_AA = (
-    "FFLLSSSSYY**CC*W"
-    "LLLLPPPPHHQQRRRR"
-    "IIIMTTTTNNKKSSRR"
-    "VVVVAAAADDEEGGGG"
-)
-CODON_TABLE = {
-    a + b + c: _AA[i]
-    for i, (a, b, c) in enumerate(itertools.product(BASES, repeat=3))
-}
-
-
-def _degeneracy(codon, pos):
-    """N-fold degeneracy of `pos` (0,1,2) in `codon` under the standard code.
-
-    Counts how many of the four nucleotides at `pos` yield the same amino acid
-    as `codon` (the codon itself counts). Returns 1 for an undefined codon (stop
-    or non-ACGT), so such codons contribute to neither the 0-fold nor 4-fold
-    set."""
-    aa = CODON_TABLE.get(codon)
-    if aa is None or aa == "*":
-        return None
-    n_same = 0
-    for b in BASES:
-        alt = codon[:pos] + b + codon[pos + 1:]
-        if CODON_TABLE.get(alt) == aa:
-            n_same += 1
-    return n_same
-
-
-# Precompute, for every sense codon and position, whether it is 0-fold or 4-fold.
-ZEROFOLD = {}   # (codon, pos) -> True/False
-FOURFOLD = {}
-for _cod in CODON_TABLE:
-    if CODON_TABLE[_cod] == "*":
-        continue
-    for _p in range(3):
-        d = _degeneracy(_cod, _p)
-        ZEROFOLD[(_cod, _p)] = (d == 1)
-        FOURFOLD[(_cod, _p)] = (d == 4)
+# The genetic code, degeneracy tables (ZEROFOLD/FOURFOLD), VALID, the PHYLIP reader
+# and the per-site pi estimator now live in _codon_diversity (imported above), so
+# pin_pis and four_fold_pi share one implementation.
 
 # ------------------------- PHYLIP I/O ------------------------
 
@@ -205,96 +169,11 @@ def resolve_phy_dir():
     return tmp, tmp
 
 
-def read_phy(path):
-    """Return list of (uppercased) sequences from a PHYLIP .phy.gz alignment.
-
-    Mirrors the sequence extraction in cds/axt_to_phy.py and four_fold_pi.py."""
-    seqs = []
-    with gzip.open(path, "rt") as fh:
-        first = fh.readline().split()
-        if len(first) != 2:
-            return [], 0
-        try:
-            exp_len = int(first[1])
-        except ValueError:
-            return [], 0
-        for line in fh:
-            if not line.strip():
-                continue
-            m = re.search(r"([ACGTNacgtn-]+)\s*$", line)
-            if m:
-                seqs.append(m.group(1).upper())
-    if not seqs:
-        return [], exp_len
-    L = len(seqs[0])
-    if any(len(s) != L for s in seqs) or L != exp_len:
-        return [], exp_len
-    return seqs, L
-
-
-# ------------------------- PI ESTIMATOR ----------------------
-
-
-def site_pi(column):
-    """Per-site pi with the Rust pipeline estimator (src/stats.rs).
-
-    Returns None for uncallable sites (< 2 called A/C/G/T haplotypes)."""
-    counts = Counter(b for b in column if b in VALID)
-    n = sum(counts.values())
-    if n < 2:
-        return None
-    sum_sq = sum(c * c for c in counts.values())
-    return n / (n - 1.0) * (1.0 - sum_sq / (n * n))
-
-
-def degenerate_columns(seqs, L):
-    """Classify each codon position as 0-fold / 4-fold across the sample.
-
-    Yields (column_index, "0" | "4"). A position is reported as 0-fold only when
-    every called haplotype carries a codon for which that position is 0-fold
-    under the standard code (likewise 4-fold). Codons with gaps/N or stops in a
-    haplotype are ignored for that haplotype; if any called haplotype disagrees
-    with the class the position is skipped. Codons must be fully called (ACGT) at
-    all three positions to vote, so the classification is well defined."""
-    for codon_start in range(0, L - 2, 3):
-        for pos in range(3):
-            col = codon_start + pos
-            is_zero = True
-            is_four = True
-            seen = False
-            for s in seqs:
-                codon = s[codon_start:codon_start + 3]
-                if any(b not in VALID for b in codon):
-                    continue
-                key = (codon, pos)
-                if key not in ZEROFOLD:   # stop codon
-                    is_zero = is_four = False
-                    break
-                seen = True
-                if not ZEROFOLD[key]:
-                    is_zero = False
-                if not FOURFOLD[key]:
-                    is_four = False
-                if not is_zero and not is_four:
-                    break
-            if not seen:
-                continue
-            if is_zero:
-                yield col, "0"
-            elif is_four:
-                yield col, "4"
-
-
-def locus_pi(seqs, columns):
-    """Mean per-site pi over the given columns (callable sites only)."""
-    vals = []
-    for col in columns:
-        p = site_pi(s[col] for s in seqs)
-        if p is not None:
-            vals.append(p)
-    if not vals:
-        return np.nan, 0
-    return float(np.mean(vals)), len(vals)
+# read_phy, site_pi, locus_pi and degenerate_columns (= classify_zero_four) are
+# imported from _codon_diversity. The per-orientation piN/piS below uses the shared
+# codon-aware class_aware_locus_pi, so a haplotype contributes its base at a 0-fold /
+# 4-fold site only when its OWN codon establishes that class (N/gap in the codon
+# excludes it) -- the same rule four_fold_pi uses.
 
 
 # ------------------------- DATA LOADING ----------------------
@@ -352,17 +231,20 @@ def collect_pin_pis(phy_dir):
         # classification is consistent across orientations, then measure pi
         # within each orientation at those sites.
         combined = s0 + s1
-        zero_cols, four_cols = [], []
+        # Reconstruct each classified column's (codon_start, pos, class) so the
+        # codon-aware estimator can re-check each haplotype's own codon family.
+        zero_sites, four_sites = [], []
         for col, cls in degenerate_columns(combined, L):
-            (zero_cols if cls == "0" else four_cols).append(col)
+            site = (col - col % 3, col % 3, cls)
+            (zero_sites if cls == "0" else four_sites).append(site)
 
         a = acc[key]
         a["n_cds"] += 1
         used = False
 
-        if zero_cols:
-            n0, n0n = locus_pi(s0, zero_cols)
-            n1, n1n = locus_pi(s1, zero_cols)
+        if zero_sites:
+            n0, n0n = class_aware_locus_pi(s0, zero_sites)
+            n1, n1n = class_aware_locus_pi(s1, zero_sites)
             if n0n:
                 a["piN0_num"] += n0 * n0n
                 a["piN0_den"] += n0n
@@ -371,9 +253,9 @@ def collect_pin_pis(phy_dir):
                 a["piN1_num"] += n1 * n1n
                 a["piN1_den"] += n1n
                 used = True
-        if four_cols:
-            s0v, s0n = locus_pi(s0, four_cols)
-            s1v, s1n = locus_pi(s1, four_cols)
+        if four_sites:
+            s0v, s0n = class_aware_locus_pi(s0, four_sites)
+            s1v, s1n = class_aware_locus_pi(s1, four_sites)
             if s0n:
                 a["piS0_num"] += s0v * s0n
                 a["piS0_den"] += s0n

--- a/stats/test_codon_diversity.py
+++ b/stats/test_codon_diversity.py
@@ -1,0 +1,82 @@
+"""Unit tests for the shared codon-diversity source of truth (stdlib + numpy only).
+
+Run: python -m pytest stats/test_codon_diversity.py   (or: python stats/test_codon_diversity.py)
+These pin the codon-aware behaviour that four_fold_pi and pin_pis both rely on, so the
+two analyses cannot silently diverge again."""
+import math
+
+from stats import _codon_diversity as cd
+
+
+def _approx(a, b, tol=1e-9):
+    return a is not None and b is not None and abs(a - b) < tol
+
+
+def test_fourfold_prefixes():
+    # The eight classic 4-fold-degenerate families (Leu/Val/Ser/Pro/Thr/Ala/Arg/Gly).
+    assert cd.FOURFOLD_PREFIXES == frozenset(
+        {"CT", "GT", "TC", "CC", "AC", "GC", "CG", "GG"}
+    )
+
+
+def test_site_pi_basic():
+    # 2 A, 1 T: n=3, 1 - (4+1)/9 = 4/9, *3/2 = 2/3.
+    assert _approx(cd.site_pi("AAT"), 2.0 / 3.0)
+    assert cd.site_pi("A") is None          # < 2 called
+    assert cd.site_pi("ANNN") is None       # only 1 called
+    assert _approx(cd.site_pi(" A T -".replace(" ", "")), 1.0)  # 'AT-' -> A,T,(-) -> 2 called, pi=1
+
+
+def test_class_aware_fourfold_simple():
+    # GCA / GCG : Ala, 4-fold at pos 3; third bases A,G -> pi = 1.0
+    pi, n = cd.class_aware_locus_pi(["GCA", "GCG"], [(0, 2, "4")])
+    assert n == 1 and _approx(pi, 1.0)
+
+
+def test_class_aware_fourfold_excludes_unknown_family():
+    # The documented bug: ['GCA','NNG'] must NOT yield pi at the 3rd position,
+    # because 'NNG' has an unknown codon family (N at positions 1-2). Only 'GCA'
+    # qualifies -> a single base -> uncallable -> no site.
+    pi, n = cd.class_aware_locus_pi(["GCA", "NNG"], [(0, 2, "4")])
+    assert n == 0 and math.isnan(pi)
+
+
+def test_class_aware_zerofold():
+    # ATG (Met) and ACG (Thr) are each 0-fold at position 2 (index 1); bases T,C -> pi=1.0
+    assert cd.ZEROFOLD[("ATG", 1)] and cd.ZEROFOLD[("ACG", 1)]
+    pi, n = cd.class_aware_locus_pi(["ATG", "ACG"], [(0, 1, "0")])
+    assert n == 1 and _approx(pi, 1.0)
+
+
+def test_class_aware_zerofold_excludes_partial_codon():
+    # A haplotype whose codon is N/gap-containing must not contribute to a 0-fold site.
+    pi, n = cd.class_aware_locus_pi(["ATG", "A-G"], [(0, 1, "0")])
+    assert n == 0 and math.isnan(pi)
+
+
+def test_classify_zero_four_combined():
+    # Two Ala codons (GCx) -> position 3 (index 2) is 4-fold; positions 1,2 are 0-fold.
+    cls = dict((col, c) for col, c in cd.classify_zero_four(["GCA", "GCC"], 3))
+    assert cls.get(2) == "4"
+    assert cls.get(0) == "0" and cls.get(1) == "0"
+
+
+def test_classify_skips_disagreeing_codons():
+    # GCA (Ala, pos3 4-fold) vs ATG (Met, pos3 0-fold) disagree at pos3 -> skipped.
+    cls = dict((col, c) for col, c in cd.classify_zero_four(["GCA", "ATG"], 3))
+    assert 2 not in cls
+
+
+def test_fourfold_codon_starts_requires_all_called_agree():
+    assert list(cd.fourfold_codon_starts(["GCA", "GCG"], 3)) == [0]   # both Ala
+    assert list(cd.fourfold_codon_starts(["GCA", "ATG"], 3)) == []    # Met not 4-fold
+    # N at positions 1-2 is ignored for classification (family unknown):
+    assert list(cd.fourfold_codon_starts(["GCA", "NNA"], 3)) == [0]
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} tests passed")


### PR DESCRIPTION
Removes the four_fold_pi/pin_pis duplication that let bug #5 hide; pin_pis pi step now codon-aware via the shared routine. Both reproduce committed data exactly (verified on phy). Adds 9 unit tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)